### PR TITLE
[FEAT] Caffein Cache 구현 및 랭킹 로직에 캐싱 처리

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -83,6 +83,10 @@ subprojects {
         // jsoup
         // https://mvnrepository.com/artifact/org.jsoup/jsoup
         implementation 'org.jsoup:jsoup:1.18.3'
+
+        // spring caffeine cache
+        implementation 'org.springframework.boot:spring-boot-starter-cache'
+        implementation 'com.github.ben-manes.caffeine:caffeine'
     }
 
     tasks.named('test') {

--- a/backend/techpick-api/src/main/java/techpick/api/application/pick/controller/PickApiController.java
+++ b/backend/techpick-api/src/main/java/techpick/api/application/pick/controller/PickApiController.java
@@ -51,7 +51,6 @@ public class PickApiController {
 	private final PickSearchService pickSearchService;
 	private final PickBulkService pickBulkService;
 	private final EventMessenger eventMessenger;
-	private final FolderService folderService;
 
 	@GetMapping
 	@Operation(summary = "폴더 리스트 내 픽 리스트 조회", description = "해당 폴더 리스트 각각의 픽 리스트를 조회합니다.")

--- a/backend/techpick-api/src/main/java/techpick/api/application/ranking/controller/RankingApiController.java
+++ b/backend/techpick-api/src/main/java/techpick/api/application/ranking/controller/RankingApiController.java
@@ -22,6 +22,7 @@ import techpick.api.application.ranking.dto.RankingResponse;
 import techpick.api.domain.link.exception.ApiLinkException;
 import techpick.api.domain.link.service.LinkService;
 import techpick.api.domain.ranking.service.RankingService;
+import techpick.core.annotation.TechpickAnnotation;
 import techpick.core.dto.UrlWithCount;
 
 /**
@@ -42,6 +43,7 @@ public class RankingApiController {
 	 * 주별, 일별 조회 수를 기반 으로 추천 한다.
 	 * - 조회수 기반 집계
 	 */
+	@TechpickAnnotation.MeasureTime
 	@GetMapping("/ranking")
 	@Operation(
 		summary = "인기 픽 Top 10",

--- a/backend/techpick-api/src/main/java/techpick/api/config/HttpApiConfiguration.java
+++ b/backend/techpick-api/src/main/java/techpick/api/config/HttpApiConfiguration.java
@@ -45,8 +45,8 @@ public class HttpApiConfiguration {
 	@Bean
 	public ClientHttpRequestFactory clientHttpRequestFactory() {
 		ClientHttpRequestFactorySettings settings = ClientHttpRequestFactorySettings.DEFAULTS
-			.withConnectTimeout(Duration.ofMillis(500))
-			.withReadTimeout(Duration.ofMillis(500));
+			.withConnectTimeout(Duration.ofSeconds(2))
+			.withReadTimeout(Duration.ofSeconds(2));
 		return ClientHttpRequestFactories.get(settings);
 	}
 }

--- a/backend/techpick-api/src/main/java/techpick/api/domain/pick/service/PickBulkService.java
+++ b/backend/techpick-api/src/main/java/techpick/api/domain/pick/service/PickBulkService.java
@@ -9,17 +9,25 @@ import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import techpick.api.domain.link.dto.LinkInfo;
 import techpick.api.domain.pick.dto.PickCommand;
+import techpick.api.infrastructure.folder.FolderDataHandler;
 import techpick.api.infrastructure.pick.PickBulkDataHandler;
+import techpick.api.infrastructure.pick.PickDataHandler;
+import techpick.core.model.folder.Folder;
+import techpick.core.model.pick.Pick;
 
 @Service
 @RequiredArgsConstructor
 public class PickBulkService {
 
+	private final FolderDataHandler folderDataHandler;
+	private final PickDataHandler pickDataHandler;
 	private final PickBulkDataHandler pickBulkDataHandler;
 
 	@Transactional
 	public void saveBulkPick(Long userId, Long parentFolderId) {
 		List<PickCommand.Create> pickList = new ArrayList<>();
+		Folder parentFolder = folderDataHandler.getFolder(parentFolderId);
+
 		for (int i = 0; i < 10000; i++) {
 			LinkInfo linkInfo = new LinkInfo("test" + i, "링크 제목", "링크 설명", "", null);
 			PickCommand.Create command = new PickCommand.Create(userId, "테스트 제목", new ArrayList<>(),
@@ -27,5 +35,10 @@ public class PickBulkService {
 			pickList.add(command);
 		}
 		pickBulkDataHandler.bulkInsertPick(pickList);
+
+		for (PickCommand.Create command : pickList) {
+			Pick pick = pickDataHandler.getPickUrl(userId, command.linkInfo().url());
+			parentFolder.addChildPickIdOrdered(pick.getId());
+		}
 	}
 }

--- a/backend/techpick-core/src/main/java/techpick/core/config/CacheConfig.java
+++ b/backend/techpick-core/src/main/java/techpick/core/config/CacheConfig.java
@@ -1,0 +1,40 @@
+package techpick.core.config;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCache;
+import org.springframework.cache.support.SimpleCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+
+import techpick.core.model.cache.CacheType;
+
+@EnableCaching
+@Configuration
+public class CacheConfig {
+
+	@Bean
+	public CacheManager cacheManager() {
+		List<CaffeineCache> caches = Arrays.stream(CacheType.values())
+			.map(cache -> new CaffeineCache(cache.getCacheName(),
+					Caffeine.newBuilder().recordStats()
+						.expireAfterWrite(cache.getExpireAfterWrite(), TimeUnit.SECONDS)
+						.maximumSize(cache.getMaximumSize())
+						.build()
+				)
+			)
+			.collect(Collectors.toList());
+
+		SimpleCacheManager cacheManager = new SimpleCacheManager();
+		cacheManager.setCaches(caches);
+
+		return cacheManager;
+	}
+}

--- a/backend/techpick-core/src/main/java/techpick/core/model/cache/CacheType.java
+++ b/backend/techpick-core/src/main/java/techpick/core/model/cache/CacheType.java
@@ -4,9 +4,9 @@ import lombok.Getter;
 
 @Getter
 public enum CacheType {
-	DAILY_LINK_RANK("daily_link_rank", 60 * 60, 10000), // 1시간
-	WEEKLY_LINK_RANK("weekly_link_rank", 24 * 60 * 60, 10000), // 24시간
-	MONTHLY_PICK_RANK("monthly_pick_rank", 3 * 60 * 60, 10000); // 3시간
+	DAILY_LINK_RANK(CACHE_NAME.DAILY_LINK_RANK, 60 * 60, 10000), // 1시간
+	WEEKLY_LINK_RANK(CACHE_NAME.WEEKLY_LINK_RANK, 24 * 60 * 60, 10000), // 24시간
+	MONTHLY_PICK_RANK(CACHE_NAME.MONTHLY_PICK_RANK, 3 * 60 * 60, 10000); // 3시간
 
 	CacheType(String cacheName, int expireAfterWrite, int maximumSize) {
 		this.cacheName = cacheName;
@@ -17,5 +17,11 @@ public enum CacheType {
 	private final String cacheName;
 	private final int expireAfterWrite;
 	private final int maximumSize;
+
+	public static class CACHE_NAME {
+		public static final String DAILY_LINK_RANK = "daily_link_rank";
+		public static final String WEEKLY_LINK_RANK = "weekly_link_rank";
+		public static final String MONTHLY_PICK_RANK = "monthly_pick_rank";
+	}
 
 }

--- a/backend/techpick-core/src/main/java/techpick/core/model/cache/CacheType.java
+++ b/backend/techpick-core/src/main/java/techpick/core/model/cache/CacheType.java
@@ -1,0 +1,20 @@
+package techpick.core.model.cache;
+
+import lombok.Getter;
+
+@Getter
+public enum CacheType {
+	DAILY_LINK_RANK("daily_link_rank", 60 * 60, 10000), // 1시간
+	WEEKLY_LINK_RANK("weekly_link_rank", 24 * 60 * 60, 10000), // 24시간
+	MONTHLY_PICK_RANK("monthly_pick_rank", 3 * 60 * 60, 10000); // 1시간
+
+	CacheType(String cacheName, int expireAfterWrite, int maximumSize) {
+		this.cacheName = cacheName;
+		this.expireAfterWrite = expireAfterWrite;
+		this.maximumSize = maximumSize;
+	}
+
+	private final String cacheName;
+	private final int expireAfterWrite;
+	private final int maximumSize;
+}

--- a/backend/techpick-core/src/main/java/techpick/core/model/cache/CacheType.java
+++ b/backend/techpick-core/src/main/java/techpick/core/model/cache/CacheType.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 public enum CacheType {
 	DAILY_LINK_RANK("daily_link_rank", 60 * 60, 10000), // 1시간
 	WEEKLY_LINK_RANK("weekly_link_rank", 24 * 60 * 60, 10000), // 24시간
-	MONTHLY_PICK_RANK("monthly_pick_rank", 3 * 60 * 60, 10000); // 1시간
+	MONTHLY_PICK_RANK("monthly_pick_rank", 3 * 60 * 60, 10000); // 3시간
 
 	CacheType(String cacheName, int expireAfterWrite, int maximumSize) {
 		this.cacheName = cacheName;
@@ -17,4 +17,5 @@ public enum CacheType {
 	private final String cacheName;
 	private final int expireAfterWrite;
 	private final int maximumSize;
+
 }

--- a/backend/techpick-ranking/src/main/java/techpick/ranking/application/RankingController.java
+++ b/backend/techpick-ranking/src/main/java/techpick/ranking/application/RankingController.java
@@ -1,6 +1,7 @@
 package techpick.ranking.application;
 
 import java.time.LocalDate;
+import java.time.Period;
 import java.util.List;
 
 import org.springframework.format.annotation.DateTimeFormat;
@@ -16,9 +17,11 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import techpick.ranking.domain.pick.PickRankingService;
 import techpick.core.dto.UrlWithCount;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/ranking")
@@ -41,7 +44,13 @@ public class RankingController {
 		@Parameter(description = "랭킹 개수, 명시 안할 경우 5개를 반환", example = "10")
 		@RequestParam(required = false, defaultValue = "5") Integer limit
 	) {
-		var result = pickRankingService.getLinksOrderByViewCount(date_begin, date_end, limit);
+		int days = Period.between(date_begin, date_end).getDays();
+		List<UrlWithCount> result;
+		if (days == 1) {
+			result = pickRankingService.getDailyLinksOrderByViewCount(date_begin, date_end, limit);
+		} else {
+			result = pickRankingService.getWeeklyLinksOrderByViewCount(date_begin, date_end, limit);
+		}
 		return ResponseEntity.ok(result);
 	}
 

--- a/backend/techpick-ranking/src/main/java/techpick/ranking/domain/pick/PickRankingService.java
+++ b/backend/techpick-ranking/src/main/java/techpick/ranking/domain/pick/PickRankingService.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import techpick.core.annotation.TechpickAnnotation;
 import techpick.core.dto.UrlWithCount;
+import techpick.core.model.cache.CacheType;
 import techpick.ranking.exception.ApiRankException;
 import techpick.ranking.infra.pick.LinkPickedCountRepository;
 import techpick.ranking.infra.pick.LinkViewCountRepository;
@@ -35,8 +36,12 @@ public class PickRankingService {
 	 *     ---------------------------------------------
 	 *     Ex. 일별 집계, 월별 집계, 연별 집계 테이블을 나눠서 미리 연산.
 	 *         API 호출은 일별, 월별, 연별을 나눠서 호출하도록 변경하면 해결 가능.
+	 *
+	 *    @author sangwon
+	 * 		 		1시간마다 캐싱하도록 처리
+	 * 		 	    CacheType Enum 참고
 	 */
-	@Cacheable(cacheNames = "daily_link_rank")
+	@Cacheable(cacheNames = CacheType.CACHE_NAME.DAILY_LINK_RANK)
 	@TechpickAnnotation.MeasureTime
 	public List<UrlWithCount> getDailyLinksOrderByViewCount(LocalDate startDate, LocalDate endDate, int limit) {
 		assertDateIsValid(startDate, endDate);
@@ -50,7 +55,12 @@ public class PickRankingService {
 			.toList();
 	}
 
-	@Cacheable(cacheNames = "weekly_link_rank")
+	/**
+	 * @author sangwon
+	 * 	 		24시간마다 캐싱하도록 처리
+	 * 	 	    CacheType Enum 참고
+	 */
+	@Cacheable(cacheNames = CacheType.CACHE_NAME.WEEKLY_LINK_RANK)
 	@TechpickAnnotation.MeasureTime
 	public List<UrlWithCount> getWeeklyLinksOrderByViewCount(LocalDate startDate, LocalDate endDate, int limit) {
 		assertDateIsValid(startDate, endDate);
@@ -67,11 +77,13 @@ public class PickRankingService {
 	/**
 	 * @author minkyeu kim
 	 *       링크가 픽된 횟수에 대한 순위표 반환
-	 *       3시간마다 캐싱하도록 처리
-	 *       CacheType Enum 참고
-	 * https://techblog.uplus.co.kr/%EB%A1%9C%EC%BB%AC-%EC%BA%90%EC%8B%9C-%EC%84%A0%ED%83%9D%ED%95%98%EA%B8%B0-e394202d5c87
+	 *
+	 * @author sangwon
+	 * 		3시간마다 캐싱하도록 처리
+	 * 	    CacheType Enum 참고
+	 * 	    https://techblog.uplus.co.kr/%EB%A1%9C%EC%BB%AC-%EC%BA%90%EC%8B%9C-%EC%84%A0%ED%83%9D%ED%95%98%EA%B8%B0-e394202d5c87
 	 */
-	@Cacheable(cacheNames = "monthly_pick_rank")
+	@Cacheable(cacheNames = CacheType.CACHE_NAME.MONTHLY_PICK_RANK)
 	@TechpickAnnotation.MeasureTime
 	public List<UrlWithCount> getLinksOrderByPickedCount(LocalDate startDate, LocalDate endDate, int limit) {
 		assertDateIsValid(startDate, endDate);

--- a/backend/techpick-ranking/src/main/java/techpick/ranking/domain/pick/PickRankingService.java
+++ b/backend/techpick-ranking/src/main/java/techpick/ranking/domain/pick/PickRankingService.java
@@ -5,13 +5,14 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import techpick.core.annotation.TechpickAnnotation;
 import techpick.core.dto.UrlWithCount;
-import techpick.ranking.exeption.ApiRankException;
+import techpick.ranking.exception.ApiRankException;
 import techpick.ranking.infra.pick.LinkPickedCountRepository;
 import techpick.ranking.infra.pick.LinkViewCountRepository;
 import techpick.core.util.MapUtil;
@@ -35,23 +36,42 @@ public class PickRankingService {
 	 *     Ex. 일별 집계, 월별 집계, 연별 집계 테이블을 나눠서 미리 연산.
 	 *         API 호출은 일별, 월별, 연별을 나눠서 호출하도록 변경하면 해결 가능.
 	 */
+	@Cacheable(cacheNames = "daily_link_rank")
 	@TechpickAnnotation.MeasureTime
-	public List<UrlWithCount> getLinksOrderByViewCount(LocalDate startDate, LocalDate endDate, int limit) {
+	public List<UrlWithCount> getDailyLinksOrderByViewCount(LocalDate startDate, LocalDate endDate, int limit) {
 		assertDateIsValid(startDate, endDate);
 		var pickViewCountList = linkViewCountRepository.findByDateBetween(
 			startDate.minusDays(1), endDate.plusDays(1)
 		);
 		return MapUtil.sortByValue(toUrlCountPair(pickViewCountList), MapUtil.SortBy.DESCENDING)
-					  .entrySet().stream()
-					  .map(v -> new UrlWithCount(v.getKey(), v.getValue()))
-					  .limit(limit)
-					  .toList();
+			.entrySet().stream()
+			.map(v -> new UrlWithCount(v.getKey(), v.getValue()))
+			.limit(limit)
+			.toList();
+	}
+
+	@Cacheable(cacheNames = "weekly_link_rank")
+	@TechpickAnnotation.MeasureTime
+	public List<UrlWithCount> getWeeklyLinksOrderByViewCount(LocalDate startDate, LocalDate endDate, int limit) {
+		assertDateIsValid(startDate, endDate);
+		var pickViewCountList = linkViewCountRepository.findByDateBetween(
+			startDate.minusDays(1), endDate.plusDays(1)
+		);
+		return MapUtil.sortByValue(toUrlCountPair(pickViewCountList), MapUtil.SortBy.DESCENDING)
+			.entrySet().stream()
+			.map(v -> new UrlWithCount(v.getKey(), v.getValue()))
+			.limit(limit)
+			.toList();
 	}
 
 	/**
 	 * @author minkyeu kim
 	 *       링크가 픽된 횟수에 대한 순위표 반환
+	 *       3시간마다 캐싱하도록 처리
+	 *       CacheType Enum 참고
+	 * https://techblog.uplus.co.kr/%EB%A1%9C%EC%BB%AC-%EC%BA%90%EC%8B%9C-%EC%84%A0%ED%83%9D%ED%95%98%EA%B8%B0-e394202d5c87
 	 */
+	@Cacheable(cacheNames = "monthly_pick_rank")
 	@TechpickAnnotation.MeasureTime
 	public List<UrlWithCount> getLinksOrderByPickedCount(LocalDate startDate, LocalDate endDate, int limit) {
 		assertDateIsValid(startDate, endDate);
@@ -59,10 +79,10 @@ public class PickRankingService {
 			startDate.minusDays(1), endDate.plusDays(1)
 		);
 		return MapUtil.sortByValue(toUrlCountPair(pickCreateCountList), MapUtil.SortBy.DESCENDING)
-					  .entrySet().stream()
-					  .map(v -> new UrlWithCount(v.getKey(), v.getValue()))
-					  .limit(limit)
-					  .toList();
+			.entrySet().stream()
+			.map(v -> new UrlWithCount(v.getKey(), v.getValue()))
+			.limit(limit)
+			.toList();
 	}
 
 	private void assertDateIsValid(LocalDate startDate, LocalDate endDate) {

--- a/backend/techpick-ranking/src/main/java/techpick/ranking/exception/ApiRankErrorCode.java
+++ b/backend/techpick-ranking/src/main/java/techpick/ranking/exception/ApiRankErrorCode.java
@@ -1,4 +1,4 @@
-package techpick.ranking.exeption;
+package techpick.ranking.exception;
 
 import org.springframework.http.HttpStatus;
 

--- a/backend/techpick-ranking/src/main/java/techpick/ranking/exception/ApiRankException.java
+++ b/backend/techpick-ranking/src/main/java/techpick/ranking/exception/ApiRankException.java
@@ -1,4 +1,4 @@
-package techpick.ranking.exeption;
+package techpick.ranking.exception;
 
 import techpick.core.exception.base.ApiErrorCode;
 import techpick.core.exception.base.ApiException;


### PR DESCRIPTION
- Close #738

## What is this PR? 🔍

- 기능 : Caffein Cache 구현 및 랭킹 로직에 캐싱 처리
- issue : #738

## Changes 📝
### 1. Caffeine Cache 구현
- 사용 이유 1 : 분산 환경이면 Redis를 두어서 여러 서버에서 하나의 캐시를 사용하면 되지만, 우리는 분산 환경이 아니므로 속도가 더 빠른 로컬 캐시 채택하였음.
- 사용 이유 2 : 로컬 캐시 중에 가장 성능이 좋음. 캐싱의 가장 큰 목적은 Read이므로 Read 성능도 가장 뛰어난 Caffeine 사용

### 2. 캐싱 처리
- 랭킹 관련 서비스에 캐싱 처리
- 일간, 주간, 월간 별로 캐시가 다르기 때문에 사용하던 메서드 랭킹 메서드 `getLinksOrderByViewCount` 2개로 분리
- end_date - start_date == 1이면 일간 캐시 적용, 아니면 주간 캐시 적용
- 월간 캐시는 따로 Api 있으므로 따로 적용
  - 일간 캐시 : 1시간 간격으로 업데이트
  - 주간 캐시 : 24시간 간격으로 업데이트
  - 월간 캐시 (픽 랭킹) : 3시간 간격으로 업데이트

### 3. Bulk Insert 수정
- 픽 bulk insert시 부모 폴더의 ChildPickList에 add해주지 않는 문제가 있어 수정

### 4. RestClient 타임아웃 500ms -> 2초로 설정