### PR TITLE
[FIX] 다른 폴더로 픽 이동 후 이동한 폴더 클릭 시 화면에 나타나지 않는 문제 수정

### DIFF
--- a/frontend/techpick/src/components/FolderTree/FolderLinkItem.tsx
+++ b/frontend/techpick/src/components/FolderTree/FolderLinkItem.tsx
@@ -1,6 +1,9 @@
+'use client';
+
 import type { ElementType, MouseEvent } from 'react';
 import Link from 'next/link';
 import { Folder } from 'lucide-react';
+import { usePickStore } from '@/stores';
 import {
   folderInfoItemStyle,
   selectedDragItemStyle,
@@ -14,11 +17,16 @@ export function FolderLinkItem({
   href,
   isSelected,
   isHovered = false,
+  folderId,
   onClick = () => {},
   icon: IconComponent = Folder,
 }: FolderListItemProps) {
+  const isMovingDestinationFolderId = usePickStore(
+    (state) => state.isMovingDestinationFolderId
+  );
+
   return (
-    <Link href={href}>
+    <Link href={isMovingDestinationFolderId === folderId ? '#' : href}>
       <div
         className={`${folderInfoItemStyle}  ${isSelected ? selectedDragItemStyle : ''} ${isHovered ? dragOverItemStyle : ''}`}
         onClick={onClick}
@@ -36,5 +44,6 @@ interface FolderListItemProps {
   isSelected?: boolean;
   isHovered?: boolean;
   onClick?: (event: MouseEvent<HTMLDivElement>) => void;
+  folderId: number;
   icon?: ElementType;
 }

--- a/frontend/techpick/src/components/FolderTree/FolderListItem.tsx
+++ b/frontend/techpick/src/components/FolderTree/FolderListItem.tsx
@@ -112,6 +112,7 @@ export const FolderListItem = ({ id, name }: FolderInfoItemProps) => {
             icon={folderIcon}
             name={name}
             onClick={(event) => handleClick(id, event)}
+            folderId={id}
           />
         </FolderDraggable>
       </FolderContextMenu>

--- a/frontend/techpick/src/components/FolderTree/FolderTreeHeader.tsx
+++ b/frontend/techpick/src/components/FolderTree/FolderTreeHeader.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Trash2Icon, ArchiveIcon } from 'lucide-react';
-import { ROUTES } from '@/constants';
+import { NON_EXIST_FOLDER_ID, ROUTES } from '@/constants';
 import { useTreeStore } from '@/stores/dndTreeStore/dndTreeStore';
 import { FolderLinkItem } from './FolderLinkItem';
 import {
@@ -46,6 +46,7 @@ export function FolderTreeHeader() {
             name="추천"
             icon={ArchiveIcon}
             isSelected={isRootSelected}
+            folderId={NON_EXIST_FOLDER_ID}
           />
 
           <PickToFolderDropZone folderId={basicFolderMap['UNCLASSIFIED'].id}>
@@ -55,6 +56,7 @@ export function FolderTreeHeader() {
               icon={ArchiveIcon}
               isSelected={isUnclassifiedSelected}
               isHovered={isUnclassifiedFolderHover}
+              folderId={basicFolderMap['UNCLASSIFIED'].id}
             />
           </PickToFolderDropZone>
           <PickToFolderDropZone folderId={basicFolderMap['RECYCLE_BIN'].id}>
@@ -64,6 +66,7 @@ export function FolderTreeHeader() {
               icon={Trash2Icon}
               isSelected={isRecycleBinSelected}
               isHovered={isRecycleBinFolderHover}
+              folderId={basicFolderMap['RECYCLE_BIN'].id}
             />
           </PickToFolderDropZone>
         </div>

--- a/frontend/techpick/src/constants/index.ts
+++ b/frontend/techpick/src/constants/index.ts
@@ -3,3 +3,4 @@ export const UNKNOWN_FOLDER_ID = -9999;
 export { ROUTES } from './route';
 export { COLOR_LIST } from './colorList';
 export { ERROR_MESSAGE_JSON } from './errorMessageJson';
+export { NON_EXIST_FOLDER_ID } from './nonExistFolderId';

--- a/frontend/techpick/src/constants/nonExistFolderId.ts
+++ b/frontend/techpick/src/constants/nonExistFolderId.ts
@@ -1,0 +1,1 @@
+export const NON_EXIST_FOLDER_ID = -1;

--- a/frontend/techpick/src/stores/pickStore/pickStore.ts
+++ b/frontend/techpick/src/stores/pickStore/pickStore.ts
@@ -30,6 +30,7 @@ const initialState: PickState = {
   selectedPickIdList: [],
   isDragging: false,
   draggingPickInfo: null,
+  isMovingDestinationFolderId: null,
 };
 
 export const usePickStore = create<PickState & PickAction>()(
@@ -211,6 +212,10 @@ export const usePickStore = create<PickState & PickAction>()(
           return;
         }
 
+        set((state) => {
+          state.isMovingDestinationFolderId = nextFolderId;
+        });
+
         // a. 다른 폴더에서 추가(0번째 인덕스)
         // 어떤 정보를 가져와야한다.
         const selectedPickIdList = get().selectedPickIdList;
@@ -316,6 +321,10 @@ export const usePickStore = create<PickState & PickAction>()(
               prevNextPickIdOrderedList;
             state.pickRecord[nextFolderId].data.pickInfoRecord =
               prevNextPickInfoRecord;
+          });
+        } finally {
+          set((state) => {
+            state.isMovingDestinationFolderId = null;
           });
         }
       },
@@ -528,6 +537,7 @@ export const usePickStore = create<PickState & PickAction>()(
           state.draggingPickInfo = draggingPickInfo;
         });
       },
+
       searchPicksByQueryParam: async (
         param: string,
         cursor?: number | string,

--- a/frontend/techpick/src/stores/pickStore/pickStore.type.ts
+++ b/frontend/techpick/src/stores/pickStore/pickStore.type.ts
@@ -17,6 +17,7 @@ export type PickState = {
   selectedPickIdList: SelectedPickIdListType;
   isDragging: boolean;
   draggingPickInfo: PickInfoType | null | undefined;
+  isMovingDestinationFolderId: number | null | undefined;
 };
 
 export type PickAction = {


### PR DESCRIPTION
- Close #762 

## What is this PR? 🔍
기능 : Post보다 Get요청이 먼저 가서 발생하는 문제를 해결했습니다. 이제 픽을 이동한 폴더는 픽 이동이 수행된 후에 이동이 됩니다.
issue : 
- #762 

## Changes 📝

https://github.com/user-attachments/assets/6bc7ec36-00cf-4a3b-a944-47670966d4c6


<!--
## ScreenShot 📷
이번 PR에서의 변경점

| Before                     | After                     |
| -------------------------- | ------------------------- |
| ![Before Image](링크_넣기) | ![After Image](링크_넣기) |
-->

## Precaution

<!-- ## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint` -->
