### PR TITLE
[FEAT] 회원 탈퇴 API

### DIFF
--- a/backend/techpick-api/src/main/java/techpick/api/application/user/controller/UserApiController.java
+++ b/backend/techpick-api/src/main/java/techpick/api/application/user/controller/UserApiController.java
@@ -1,0 +1,39 @@
+package techpick.api.application.user.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import techpick.api.domain.user.service.UserService;
+import techpick.security.annotation.LoginUserId;
+import techpick.security.handler.TechPickLogoutHandler;
+
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
+@Tag(name = "User API", description = "유저 API")
+public class UserApiController {
+
+	private final UserService userService;
+	private final TechPickLogoutHandler techPickLogoutHandler;
+
+	@DeleteMapping
+	@Operation(summary = "회원 탈퇴", description = "회원 탈퇴를 하면 모든 폴더, 픽, 태그가 삭제됩니다.")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "204", description = "회원 탈퇴 성공")
+	})
+	public ResponseEntity<Void> deleteUser(@LoginUserId Long userId, HttpServletRequest request,
+		HttpServletResponse response) {
+		userService.deleteUser(userId);
+		techPickLogoutHandler.clearCookies(request, response);
+		return ResponseEntity.noContent().build();
+	}
+}

--- a/backend/techpick-api/src/main/java/techpick/api/domain/pick/service/PickService.java
+++ b/backend/techpick-api/src/main/java/techpick/api/domain/pick/service/PickService.java
@@ -83,7 +83,6 @@ public class PickService {
 	}
 
 	// 폴더 리스트가 넘어오면, 각 폴더 내부에 있는 픽 리스트 조회
-	@LoginUserIdDistributedLock
 	@Transactional(readOnly = true)
 	public List<PickResult.FolderPickWithViewCountList> getFolderListChildPickList(PickCommand.ReadList command) {
 		return command.folderIdList().stream()

--- a/backend/techpick-api/src/main/java/techpick/api/domain/user/service/UserService.java
+++ b/backend/techpick-api/src/main/java/techpick/api/domain/user/service/UserService.java
@@ -1,9 +1,11 @@
 package techpick.api.domain.user.service;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 import techpick.api.domain.user.service.strategy.StarterFolderStrategy;
+import techpick.api.infrastructure.user.UserDataHandler;
 import techpick.core.annotation.TechpickAnnotation;
 import techpick.core.model.folder.Folder;
 import techpick.core.model.folder.FolderRepository;
@@ -15,6 +17,7 @@ import techpick.security.model.OAuth2UserInfo;
 @RequiredArgsConstructor
 public class UserService {
 
+	private final UserDataHandler userDataHandler;
 	private final UserRepository userRepository;
 	private final FolderRepository folderRepository;
 	private final StarterFolderStrategy folderStrategy;
@@ -44,6 +47,11 @@ public class UserService {
 			);
 			createBasicFolder(userRepository.save(user));
 		}
+	}
+
+	@Transactional
+	public void deleteUser(Long userId) {
+		userDataHandler.deleteUser(userId);
 	}
 
 	private void createBasicFolder(User user) {

--- a/backend/techpick-api/src/main/java/techpick/api/infrastructure/pick/PickDataHandler.java
+++ b/backend/techpick-api/src/main/java/techpick/api/infrastructure/pick/PickDataHandler.java
@@ -129,7 +129,7 @@ public class PickDataHandler {
 	 */
 	@Transactional
 	public Pick updatePick(PickCommand.Update command) {
-		Pick pick = pickRepository.findByIdForUpdate(command.id()).orElseThrow(ApiPickException::PICK_NOT_FOUND);
+		Pick pick = pickRepository.findById(command.id()).orElseThrow(ApiPickException::PICK_NOT_FOUND);
 		pick.updateTitle(command.title());
 
 		if (command.parentFolderId() != null) {

--- a/backend/techpick-api/src/main/java/techpick/api/infrastructure/user/UserDataHandler.java
+++ b/backend/techpick-api/src/main/java/techpick/api/infrastructure/user/UserDataHandler.java
@@ -1,20 +1,48 @@
 package techpick.api.infrastructure.user;
 
+import java.util.List;
+
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 import techpick.api.domain.user.exception.ApiUserException;
+import techpick.core.model.folder.FolderRepository;
+import techpick.core.model.pick.PickRepository;
+import techpick.core.model.pick.PickTagRepository;
+import techpick.core.model.sharedFolder.SharedFolderRepository;
+import techpick.core.model.tag.TagRepository;
 import techpick.core.model.user.User;
 import techpick.core.model.user.UserRepository;
 
 @Component
 @RequiredArgsConstructor
 public class UserDataHandler {
+
 	private final UserRepository userRepository;
+	private final FolderRepository folderRepository;
+	private final SharedFolderRepository sharedFolderRepository;
+	private final PickRepository pickRepository;
+	private final PickTagRepository pickTagRepository;
+	private final TagRepository tagRepository;
 
 	@Transactional(readOnly = true)
 	public User getUser(Long userId) {
 		return userRepository.findById(userId).orElseThrow(ApiUserException::USER_NOT_FOUND);
+	}
+
+	/**
+	 * @author sangwon
+	 * 회원 탈퇴 기능
+	 */
+	@Transactional
+	public void deleteUser(Long userId) {
+		List<Long> pickIdList = pickRepository.findIdAllByUserId(userId);
+		pickTagRepository.deleteAllByPickList(pickIdList);
+		pickRepository.deleteAllByIdInBatch(pickIdList);
+		tagRepository.deleteByUserId(userId);
+		sharedFolderRepository.deleteByUserId(userId);
+		folderRepository.deleteByUserId(userId);
+		userRepository.deleteById(userId);
 	}
 }

--- a/backend/techpick-api/src/main/java/techpick/security/handler/TechPickLogoutHandler.java
+++ b/backend/techpick-api/src/main/java/techpick/security/handler/TechPickLogoutHandler.java
@@ -19,23 +19,24 @@ public class TechPickLogoutHandler implements LogoutHandler, LogoutSuccessHandle
 	private final SecurityProperties properties;
 
 	@Override
-	public void logout(
-		HttpServletRequest request,
-		HttpServletResponse response,
-		Authentication authentication
-	) {
-		cookieUtil.deleteCookie(request, response, properties.ACCESS_TOKEN_KEY);
-		cookieUtil.deleteCookie(request, response, properties.LOGIN_FLAG_FOR_FRONTEND);
-		cookieUtil.deleteCookie(request, response, "JSESSIONID");
+	public void logout(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
+		clearCookies(request, response);
 	}
 
 	@Override
-	public void onLogoutSuccess(
-		HttpServletRequest request,
-		HttpServletResponse response,
-		Authentication authentication
-	) {
-		// do not redirect
+	public void onLogoutSuccess(HttpServletRequest request, HttpServletResponse response,
+		Authentication authentication) {
 		response.setStatus(HttpServletResponse.SC_OK);
+	}
+
+	/**
+	 * @author sangwon
+	 * 쿠키 삭제 메서드 분리 (공통으로 사용하기 위함)
+	 * 시큐리티, 쿠키를 제거해주고 싶은 컨트롤러에서 사용하기 위해 분리
+	 */
+	public void clearCookies(HttpServletRequest request, HttpServletResponse response) {
+		cookieUtil.deleteCookie(request, response, properties.ACCESS_TOKEN_KEY);
+		cookieUtil.deleteCookie(request, response, properties.LOGIN_FLAG_FOR_FRONTEND);
+		cookieUtil.deleteCookie(request, response, "JSESSIONID");
 	}
 }

--- a/backend/techpick-core/src/main/java/techpick/core/model/folder/FolderRepository.java
+++ b/backend/techpick-core/src/main/java/techpick/core/model/folder/FolderRepository.java
@@ -22,7 +22,7 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
 	Optional<Folder> findByIdForUpdate(Long id);
 
 	List<Folder> findByUserId(Long userId);
-	
+
 	List<Folder> findByParentFolderId(Long parentFolderId);
 
 	// TODO: QueryDSL 도입 후 리팩토링 필요
@@ -36,4 +36,6 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
 	// TODO: QueryDSL 도입 후 리팩토링 필요
 	@Query("SELECT f FROM Folder f WHERE f.user.id = :userId AND f.folderType = techpick.core.model.folder.FolderType.ROOT")
 	Folder findRootByUserId(@Param("userId") Long userId);
+
+	void deleteByUserId(Long userId);
 }

--- a/backend/techpick-core/src/main/java/techpick/core/model/pick/PickRepository.java
+++ b/backend/techpick-core/src/main/java/techpick/core/model/pick/PickRepository.java
@@ -15,21 +15,15 @@ import techpick.core.model.user.User;
 
 public interface PickRepository extends JpaRepository<Pick, Long> {
 
-    Optional<Pick> findByUserIdAndLinkUrl(Long userId, String url);
+	Optional<Pick> findByUserIdAndLinkUrl(Long userId, String url);
 
-    @Lock(value = LockModeType.PESSIMISTIC_WRITE)
-    @QueryHints({
-        @QueryHint(name = "javax.persistence.lock.timeout", value = "3000")
-    })
-    @Query("SELECT p FROM Pick p WHERE p.id = :id")
-    Optional<Pick> findByIdForUpdate(Long id);
+	Optional<Pick> findByUserAndLink(User user, Link link);
 
-    Optional<Pick> findByUserAndLink(User user, Link link);
+	boolean existsByUserIdAndLink(Long userId, Link link);
 
-    boolean existsByUserIdAndLink(Long userId, Link link);
+	@Query("SELECT p.id FROM Pick p WHERE p.user.id = :userId")
+	List<Long> findIdAllByUserId(Long userId);
 
-    List<Pick> findAllByUserId(Long userId);
-
-    @Query("SELECT p from Pick p JOIN FETCH p.link WHERE p.id IN (:pickIdList)")
-    List<Pick> findAllById_JoinLink(List<Long> pickIdList);
+	@Query("SELECT p from Pick p JOIN FETCH p.link WHERE p.id IN (:pickIdList)")
+	List<Pick> findAllById_JoinLink(List<Long> pickIdList);
 }

--- a/backend/techpick-core/src/main/java/techpick/core/model/pick/PickTagRepository.java
+++ b/backend/techpick-core/src/main/java/techpick/core/model/pick/PickTagRepository.java
@@ -4,6 +4,8 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface PickTagRepository extends JpaRepository<PickTag, Long> {
 
@@ -17,5 +19,7 @@ public interface PickTagRepository extends JpaRepository<PickTag, Long> {
 
 	void deleteByTagId(Long tagId);
 
-	void deleteByPickAndTagId(Pick pick, Long tagId);
+	@Modifying
+	@Query("DELETE FROM PickTag pt WHERE pt.pick.id IN :pickIdList")
+	void deleteAllByPickList(List<Long> pickIdList);
 }

--- a/backend/techpick-core/src/main/java/techpick/core/model/sharedFolder/SharedFolderRepository.java
+++ b/backend/techpick-core/src/main/java/techpick/core/model/sharedFolder/SharedFolderRepository.java
@@ -10,9 +10,11 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public interface SharedFolderRepository extends JpaRepository<SharedFolder, UUID> {
 
-    List<SharedFolder> findByUserId(Long userId);
+	List<SharedFolder> findByUserId(Long userId);
 
-    Optional<SharedFolder> findByFolderId(Long folderId);
+	Optional<SharedFolder> findByFolderId(Long folderId);
 
-    void deleteByFolderId(Long folderId);
+	void deleteByFolderId(Long folderId);
+
+	void deleteByUserId(Long userId);
 }

--- a/backend/techpick-core/src/main/java/techpick/core/model/tag/TagRepository.java
+++ b/backend/techpick-core/src/main/java/techpick/core/model/tag/TagRepository.java
@@ -11,4 +11,6 @@ public interface TagRepository extends JpaRepository<Tag, Long> {
 	List<Tag> findAllByUserId(Long userId);
 
 	void deleteByIdAndUserId(Long id, Long userId);
+
+	void deleteByUserId(Long userId);
 }

--- a/backend/techpick-core/src/main/java/techpick/core/model/user/User.java
+++ b/backend/techpick-core/src/main/java/techpick/core/model/user/User.java
@@ -1,12 +1,8 @@
 package techpick.core.model.user;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-
-import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.SQLRestriction;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
@@ -24,8 +20,6 @@ import lombok.NoArgsConstructor;
 import techpick.core.model.common.BaseEntity;
 import techpick.core.util.OrderConverter;
 
-@SQLDelete(sql = "UPDATE user SET deleted_at = CURRENT_TIMESTAMP WHERE user.id=?")
-@SQLRestriction("deleted_at IS NULL")
 @Table(name = "user")
 @Entity
 @Getter
@@ -64,10 +58,6 @@ public class User extends BaseEntity /* implements UserDetails --> 시큐리티 
 	// 소셜 제공자 Id
 	@Column(name = "social_provider_id") // nullable
 	private String socialProviderId;
-
-	// Soft Delete - 삭제 시간
-	@Column(name = "deleted_at") // nullable
-	private LocalDateTime deletedAt;
 
 	// 유저의 tag id들을 공백으로 분리된 String으로 변환하여 db에 저장
 	// ex) [6,3,2,23,1] -> "6 3 2 23 1"


### PR DESCRIPTION
- Close #763

## What is this PR? 🔍

- 기능 : 회원 탈퇴 API
- issue : #763

## Changes 📝
- 불필요한 락 제거
- 유저 soft delete 제거
- 회원 탈퇴 API 구현
  - 회원 탈퇴 시 (폴더, 공유 폴더, 픽, 태그) 모두 삭제

## Precautions
어드민에서 회원 탈퇴시키는 기능을 구현하려고 했으나, 외부에서 해당 API를 알게 된다면 위험해질 것으로 예상함.
누군가 악의적으로 접근하여 모든 회원의 정보를 탈퇴시킬 수 있다고 생각하여 MySQL의 프로시저 이용해서 DB 서버에서 삭제하도록 변경
- #774 

어드민 모듈은 추후에 다시 구현할 예정