### PR TITLE
[FIX] 폴더 이동 후 포커싱 문제 수정

### DIFF
--- a/frontend/techpick/src/app/(signed)/mypage/page.tsx
+++ b/frontend/techpick/src/app/(signed)/mypage/page.tsx
@@ -17,6 +17,9 @@ import {
 
 export default function MyPage() {
   const setFocusFolderId = useTreeStore((state) => state.setFocusFolderId);
+  const setSelectedFolderList = useTreeStore(
+    (state) => state.setSelectedFolderList
+  );
 
   const handleLogout = async () => {
     try {
@@ -30,8 +33,9 @@ export default function MyPage() {
   useEffect(
     function clearFocusFolderId() {
       setFocusFolderId(null);
+      setSelectedFolderList([]);
     },
-    [setFocusFolderId]
+    [setFocusFolderId, setSelectedFolderList]
   );
 
   return (


### PR DESCRIPTION
- Close #783 

## What is this PR? 🔍

- 기능 :
- issue : #783 

## Changes 📝
- 기본 폴더가 아닌 사용자가 만든 폴더에서 마이 페이지로 이동할 때, 포커싱이 유지되는 문제를 수정했습니다.

<!--
## ScreenShot 📷
이번 PR에서의 변경점

| Before                     | After                     |
| -------------------------- | ------------------------- |
| ![Before Image](링크_넣기) | ![After Image](링크_넣기) |
-->

## Precaution

<!-- ## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint` -->
