### PR TITLE
[FEAT] 로그인 실패 UI 추가

### DIFF
--- a/frontend/techpick/src/app/(unsigned)/login/failed/page.css.ts
+++ b/frontend/techpick/src/app/(unsigned)/login/failed/page.css.ts
@@ -93,3 +93,9 @@ export const kakaoLoginContainer = style({
     border: `1px solid ${colorVars.primary}`,
   },
 });
+
+export const failedDescriptionTextStyle = style({
+  height: '28px',
+  fontSize: '12px',
+  color: colorVars.tomato11,
+});

--- a/frontend/techpick/src/app/(unsigned)/login/failed/page.tsx
+++ b/frontend/techpick/src/app/(unsigned)/login/failed/page.tsx
@@ -1,0 +1,76 @@
+import Image from 'next/image';
+import Link from 'next/link';
+import {
+  dividerStyle,
+  failedDescriptionTextStyle,
+  googleLoginContainer,
+  kakaoLoginContainer,
+  loginBlockContainer,
+  loginLink,
+  pickBrandContainer,
+  pickBrandContainerWithText,
+  pickIconContainer,
+  screenContainer,
+} from './page.css';
+
+export default function LoginFailedPage() {
+  const redirectUrl = encodeURIComponent(
+    process.env.NEXT_PUBLIC_REDIRECT_URL ?? ''
+  );
+
+  return (
+    <div className={screenContainer}>
+      <div className={loginBlockContainer}>
+        <div className={pickBrandContainer}>
+          <div className={pickBrandContainerWithText}>
+            <div className={pickIconContainer}>
+              <Image
+                src={`/image/logo_techpick.png`}
+                alt="TechPick Logo"
+                fill
+                objectFit={'contain'}
+              />
+            </div>
+            <h1>SIGN UP</h1>
+          </div>
+        </div>
+        <hr className={dividerStyle} />
+        <div style={{ paddingTop: '36px', paddingBottom: '8px' }}>
+          <div className={googleLoginContainer}>
+            <Link
+              className={loginLink}
+              href={`${process.env.NEXT_PUBLIC_API}/login/google?redirectUrl=${redirectUrl}`}
+            >
+              <Image
+                style={{ filter: 'brightness(100)' }}
+                src={`/image/logo_google.png`}
+                alt="Google Logo"
+                width={20}
+                height={20}
+              />
+              <span>Sign up with Google</span>
+            </Link>
+          </div>
+          <div className={kakaoLoginContainer}>
+            <Link
+              className={loginLink}
+              href={`${process.env.NEXT_PUBLIC_API}/login/kakao?redirectUrl=${redirectUrl}`}
+            >
+              <Image
+                style={{ filter: 'invert(100%)' }}
+                src={`/image/logo_kakao.svg`}
+                alt="Kakao Logo"
+                width={20}
+                height={20}
+              />
+              Sign up with Kakao
+            </Link>
+          </div>
+          <div className={failedDescriptionTextStyle}>
+            <p>죄송합니다. 로그인에 실패했습니다. </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
- Close #744 

## What is this PR? 🔍

- 기능 :
- 로그인 실패 UI를 추가했습니다.  (로그인 화면과 동일하고 실패했다는 글자만 추가되었습니다.)
- issue : #744 

## Changes 📝
<img width="516" alt="스크린샷 2024-12-15 오후 2 33 52" src="https://github.com/user-attachments/assets/d9dc50b3-d880-423e-905d-0358f38b8254" />


<!--
## ScreenShot 📷
이번 PR에서의 변경점

| Before                     | After                     |
| -------------------------- | ------------------------- |
| ![Before Image](링크_넣기) | ![After Image](링크_넣기) |
-->

## Precaution

<!-- ## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint` -->
