### PR TITLE
[FIX] Image컴포넌트 대신 img 적용

### DIFF
--- a/frontend/techpick/src/components/RecommendedPickCarousel/PickCarouselCard.tsx
+++ b/frontend/techpick/src/components/RecommendedPickCarousel/PickCarouselCard.tsx
@@ -8,6 +8,7 @@ import {
   pickTitleStyle,
   pickImageStyle,
   defaultImageStyle,
+  defaultImageLayoutStyle,
 } from './pickCarouselCard.css';
 import { RecommendPickType } from '@/types';
 
@@ -26,23 +27,17 @@ export function PickCarouselCard({ recommendPick }: PickCarouselCardProps) {
   return (
     <div className={pickCarouselItemStyle} onClick={onOpenLink}>
       {recommendPick.imageUrl === '' ? (
-        <div className={defaultImageStyle}>
+        <div className={defaultImageLayoutStyle}>
           <Image
             src={'/image/default_image.svg'}
             alt=""
-            className={pickImageStyle}
+            className={`${defaultImageStyle}`}
             width="80"
             height="65"
-            style={{
-              position: 'absolute',
-              top: '50%',
-              left: '50%',
-              transform: 'translate(-50%, -50%)',
-            }}
           />
         </div>
       ) : (
-        <Image
+        <img
           src={recommendPick.imageUrl}
           alt=""
           className={pickImageStyle}

--- a/frontend/techpick/src/components/RecommendedPickCarousel/pickCarouselCard.css.ts
+++ b/frontend/techpick/src/components/RecommendedPickCarousel/pickCarouselCard.css.ts
@@ -29,6 +29,16 @@ export const pickImageStyle = style([
   },
 ]);
 
+export const defaultImageStyle = style([
+  pickImageStyle,
+  {
+    position: 'absolute',
+    top: '50%',
+    left: '50%',
+    transform: 'translate(-50%, -50%)',
+  },
+]);
+
 export const pickTitleStyle = style({
   display: '-webkit-box',
   width: '100%',
@@ -44,7 +54,7 @@ export const pickTitleStyle = style({
   WebkitBoxOrient: 'vertical',
 });
 
-export const defaultImageStyle = style([
+export const defaultImageLayoutStyle = style([
   imageStyle,
   {
     width: '250px',


### PR DESCRIPTION
- Close #802 

## What is this PR? 🔍

- 기능 :
- issue : #802 

## Changes 📝
- vercel의 배포 환경에서 Image 컴포넌트로 캐싱된 이미지가 잘못 불러와지는 걸 확인했습니다. 따라서 일반 img컴포넌트로 바꿔 테스트해봅니다.

<!--
## ScreenShot 📷
이번 PR에서의 변경점

| Before                     | After                     |
| -------------------------- | ------------------------- |
| ![Before Image](링크_넣기) | ![After Image](링크_넣기) |
-->

## Precaution

<!-- ## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint` -->
