### PR TITLE
[BUG] 픽 제목 수정 시 픽 리스트 순서가 변경되는 문제

### DIFF
--- a/backend/baguni-api/src/main/java/baguni/api/infrastructure/pick/PickDataHandler.java
+++ b/backend/baguni-api/src/main/java/baguni/api/infrastructure/pick/PickDataHandler.java
@@ -132,15 +132,6 @@ public class PickDataHandler {
 		Pick pick = pickRepository.findById(command.id()).orElseThrow(ApiPickException::PICK_NOT_FOUND);
 		pick.updateTitle(command.title());
 
-		if (command.parentFolderId() != null) {
-			Folder parentFolder = pick.getParentFolder();
-			Folder destinationFolder = folderRepository.findById(command.parentFolderId())
-													   .orElseThrow(ApiFolderException::FOLDER_NOT_FOUND);
-
-			detachPickFromParentFolder(pick, parentFolder);
-			attachPickToParentFolder(pick, destinationFolder);
-			updatePickParentFolder(pick, destinationFolder);
-		}
 		if (command.tagIdOrderedList() != null) {
 			updateNewTagIdList(pick, command.tagIdOrderedList());
 		}


### PR DESCRIPTION
- Close #833

## What is this PR? 🔍

- 기능 : 픽 제목 수정 시 픽 리스트 순서가 변경되는 문제
- issue : #833

## Changes 📝
### 원인
- 기존에 사용하던 픽 수정 API 수정이 이루어지지 않음.
- 기존에 픽 수정 API에서 픽 이동까지 한 번에 했었습니다. 
- 그로 인해 부모 폴더의 자식 픽 리스트가 수정되는 문제가 발생 (삭제 후 삽입하여 리스트의 첫 번째로 이동됨)

### 해결
- 관련 로직이 남아있었어서 이동과 관련된 로직을 삭제하여 해결하였습니다.
