### PR TITLE
[CHORE] JPA 링크 엔티티 image_url을 TEXT로 변경

### DIFF
--- a/backend/baguni-core/src/main/java/baguni/core/model/link/Link.java
+++ b/backend/baguni-core/src/main/java/baguni/core/model/link/Link.java
@@ -42,7 +42,8 @@ public class Link {
 	@Column(name = "description", columnDefinition = "TEXT")
 	private String description;
 
-	@Column(name = "imageUrl", columnDefinition = "VARCHAR(600)")
+	// image가 base64 로 인코딩되서 url에 담기는 경우가 있기 때문에 text로 변경
+	@Column(name = "imageUrl", columnDefinition = "TEXT")
 	private String imageUrl;
 
 	@Column(name = "invalidatedAt_at")


### PR DESCRIPTION
- Close #858 

## What is this PR? 🔍
DB에는 image_url이 text로 되어 있지만, JPA 엔티티는 TEXT가 아니기 때문에 
이를 수정하였습니다.
