### PR TITLE
[FIX] 배포 스크립트에서 도커 이미지 정리 코드 제거

### DIFF
--- a/.github/workflows/baguni.test.api.deploy.yml
+++ b/.github/workflows/baguni.test.api.deploy.yml
@@ -73,9 +73,6 @@ jobs:
             docker compose down ${{ env.module-name }}
             docker compose up ${{ env.module-name }} -d
 
-            echo "docker - pruning images that passed 24h ..."
-            docker image prune -af --filter "until=24h"
-
       - name: Discord Webhook Notification
         uses: sarisia/actions-status-discord@v1.14.7
         if: always()

--- a/.github/workflows/baguni.test.batch.deploy.yml
+++ b/.github/workflows/baguni.test.batch.deploy.yml
@@ -73,9 +73,6 @@ jobs:
             docker compose down ${{ env.module-name }}
             docker compose up ${{ env.module-name }} -d
 
-            echo "docker - pruning images that passed 24h ..."
-            docker image prune -af --filter "until=24h"
-
       - name: Discord Webhook Notification
         uses: sarisia/actions-status-discord@v1.14.7
         if: always()

--- a/.github/workflows/baguni.test.ranking.deploy.yml
+++ b/.github/workflows/baguni.test.ranking.deploy.yml
@@ -72,9 +72,6 @@ jobs:
             echo "restarting container..."
             docker compose down ${{ env.module-name }}
             docker compose up ${{ env.module-name }} -d
-            
-            echo "docker - pruning images that passed 24h ..."
-            docker image prune -af --filter "until=24h"
 
       - name: Discord Webhook Notification
         uses: sarisia/actions-status-discord@v1.14.7


### PR DESCRIPTION
- Close #865 

## What is this PR? 🔍

- 기능 : 
1. 도커 이미지 정리 코드를 배포 스크립트에서 제거함.
2. 서버 내 crontab으로 도커 이미지 정리 스케쥴 등록
- issue : #865 

### 홈서버 내 설정
![image](https://github.com/user-attachments/assets/9488fae9-ce5c-4b14-b1d7-09e0c6ebf38d)
- 참고 
   https://alexgallacher.com/prune-unused-docker-images-automatically/