### PR TITLE
[REFACTOR] 중복 스타일링 제거

### DIFF
--- a/frontend/techpick/src/app/(signed)/mypage/page.css.ts
+++ b/frontend/techpick/src/app/(signed)/mypage/page.css.ts
@@ -1,5 +1,6 @@
 import { style } from '@vanilla-extract/css';
 import { colorVars } from 'techpick-shared';
+import { redOutlineButtonStyle } from '@/styles/redButtonStyle.css';
 
 export const myPageLayoutStyle = style({
   width: '100%',
@@ -8,24 +9,13 @@ export const myPageLayoutStyle = style({
   backgroundColor: colorVars.gold2,
 });
 
-export const logoutButtonStyle = style({
-  width: '120px',
-  height: '32px',
-  border: '1px solid',
-  borderColor: colorVars.red8,
-  borderRadius: '4px',
-  transition: 'background-color 0.3s ease',
-  color: colorVars.red11,
-  cursor: 'pointer',
-
-  ':hover': {
-    backgroundColor: colorVars.red3,
+export const logoutButtonStyle = style([
+  redOutlineButtonStyle,
+  {
+    width: '120px',
+    height: '32px',
   },
-
-  ':focus': {
-    backgroundColor: colorVars.red3,
-  },
-});
+]);
 
 export const myPageContentContainerLayoutStyle = style({
   display: 'flex',

--- a/frontend/techpick/src/components/CreatePickPopover/createPickPopoverButton.css.ts
+++ b/frontend/techpick/src/components/CreatePickPopover/createPickPopoverButton.css.ts
@@ -1,5 +1,6 @@
 import { style } from '@vanilla-extract/css';
 import { colorVars } from 'techpick-shared';
+import { greenOutlineButtonStyle } from '@/styles/greenButtonStyle.css';
 
 export const popoverTriggerStyle = style({
   display: 'flex',
@@ -46,24 +47,15 @@ export const urlInputStyle = style({
   },
 });
 
-export const createPickButtonStyle = style({
-  marginTop: '8px',
-  width: '100%',
-  height: '20px',
-  border: '1px solid',
-  borderColor: colorVars.green8,
-  borderRadius: '4px',
-  transition: 'background-color 0.3s ease',
-  color: colorVars.green11,
-  cursor: 'pointer',
-  fontSize: '12px',
-
-  selectors: {
-    '&:hover, &:focus': {
-      backgroundColor: colorVars.green3,
-    },
+export const createPickButtonStyle = style([
+  greenOutlineButtonStyle,
+  {
+    marginTop: '8px',
+    width: '100%',
+    height: '20px',
+    fontSize: '12px',
   },
-});
+]);
 
 export const wrongDescriptionTextStyle = style({
   display: 'inline-block',

--- a/frontend/techpick/src/components/DragOverlay/FolderItemOverlay.tsx
+++ b/frontend/techpick/src/components/DragOverlay/FolderItemOverlay.tsx
@@ -1,9 +1,9 @@
 import { FolderOpen as FolderOpenIcon } from 'lucide-react';
+import { folderItemOverlay } from './folderItemOverlay.css';
 import {
-  folderItemOverlay,
   FolderIconStyle,
   folderTextStyle,
-} from './folderItemOverlay.css';
+} from '../FolderTree/folderLinkItem.css';
 
 export function FolderItemOverlay({ name }: FolderItemOverlayProps) {
   return (

--- a/frontend/techpick/src/components/DragOverlay/PickRecordOverlay.tsx
+++ b/frontend/techpick/src/components/DragOverlay/PickRecordOverlay.tsx
@@ -4,16 +4,16 @@ import Image from 'next/image';
 import { ExternalLink as ExternalLinkIcon } from 'lucide-react';
 import { useTagStore } from '@/stores';
 import { formatDateString } from '@/utils';
+import { pickRecordOverlayLayoutStyle } from './pickRecordOverlay.css';
+import { PickDateColumnLayout } from '../PickRecord/PickDateColumnLayout';
+import { PickImageColumnLayout } from '../PickRecord/PickImageColumnLayout';
 import {
-  pickRecordLayoutStyle,
   pickImageStyle,
   pickTitleSectionStyle,
   dateTextStyle,
-  externalLinkIconStyle,
   linkLayoutStyle,
-} from './pickRecordOverlay.css';
-import { PickDateColumnLayout } from '../PickRecord/PickDateColumnLayout';
-import { PickImageColumnLayout } from '../PickRecord/PickImageColumnLayout';
+  externalLinkIconStyle,
+} from '../PickRecord/pickRecord.css';
 import { PickTagColumnLayout } from '../PickRecord/PickTagColumnLayout';
 import { PickTitleColumnLayout } from '../PickRecord/PickTitleColumnLayout';
 import { Separator } from '../PickRecord/Separator';
@@ -35,7 +35,7 @@ export function PickRecordOverlay({ pickInfo }: PickViewItemComponentProps) {
   });
 
   return (
-    <div className={pickRecordLayoutStyle}>
+    <div className={pickRecordOverlayLayoutStyle}>
       <PickImageColumnLayout>
         <div className={pickImageStyle}>
           {link.imageUrl ? (

--- a/frontend/techpick/src/components/DragOverlay/folderItemOverlay.css.ts
+++ b/frontend/techpick/src/components/DragOverlay/folderItemOverlay.css.ts
@@ -1,28 +1,12 @@
 import { style } from '@vanilla-extract/css';
-import { colorVars, sizes, space, fontSize } from 'techpick-shared';
+import { colorVars } from 'techpick-shared';
+import { folderInfoItemStyle } from '../FolderTree/folderLinkItem.css';
 
-export const folderItemOverlay = style({
-  display: 'flex',
-  alignItems: 'center',
-  gap: space['8'],
-  minWidth: sizes['6xs'],
-  height: '36px',
-  padding: '8px 12px',
-  borderRadius: '4px',
-  backgroundColor: colorVars.gold4,
-  fontSize: fontSize['sm'],
-  color: colorVars.point,
-  opacity: '0.8',
-});
-
-export const FolderIconStyle = style({
-  width: '16px',
-  flexShrink: 0,
-});
-
-export const folderTextStyle = style({
-  overflow: 'hidden',
-  whiteSpace: 'nowrap',
-  textOverflow: 'ellipsis',
-  height: '28px',
-});
+export const folderItemOverlay = style([
+  folderInfoItemStyle,
+  {
+    color: colorVars.point,
+    backgroundColor: colorVars.gold4,
+    opacity: '0.8',
+  },
+]);

--- a/frontend/techpick/src/components/DragOverlay/pickRecordOverlay.css.ts
+++ b/frontend/techpick/src/components/DragOverlay/pickRecordOverlay.css.ts
@@ -1,65 +1,11 @@
 import { style } from '@vanilla-extract/css';
-import { colorVars, typography } from 'techpick-shared';
+import { colorVars } from 'techpick-shared';
+import { pickRecordLayoutStyle } from '../PickRecord/pickRecord.css';
 
-export const pickRecordLayoutStyle = style({
-  position: 'relative',
-  display: 'flex',
-  alignItems: 'center',
-  width: '1044px',
-  minHeight: '60px',
-  height: 'fit-content',
-  borderTop: '0.5px solid',
-  borderBottom: '0.5px solid',
-  borderColor: colorVars.gold7,
-  background: colorVars.gold3,
-  opacity: '0.8',
-});
-
-export const pickImageStyle = style({
-  position: 'relative',
-  width: '96px',
-  aspectRatio: '1280 / 630',
-  // objectFit: 'cover',
-  borderRadius: '2px',
-});
-
-export const pickTitleSectionStyle = style({
-  fontSize: typography.fontSize['sm'],
-  fontWeight: typography.fontWeights['light'],
-  minHeight: '20px',
-  maxHeight: '40px',
-  lineHeight: '20px',
-  overflow: 'hidden',
-  textOverflow: 'ellipsis',
-  cursor: 'pointer',
-  wordBreak: 'break-all',
-  display: '-webkit-box',
-  WebkitLineClamp: 2,
-  WebkitBoxOrient: 'vertical',
-});
-
-export const dateTextStyle = style({
-  fontSize: typography.fontSize['sm'],
-  fontWeight: typography.fontWeights['normal'],
-  color: colorVars.gray11,
-  whiteSpace: 'nowrap',
-});
-
-export const linkLayoutStyle = style({
-  position: 'absolute',
-  width: '104px',
-  height: '60px',
-  backgroundColor: colorVars.gold12,
-  opacity: '0.7',
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  cursor: 'pointer',
-});
-
-export const externalLinkIconStyle = style({
-  width: '28px',
-  height: '28px',
-  cursor: 'pointer',
-  color: colorVars.white,
-});
+export const pickRecordOverlayLayoutStyle = style([
+  pickRecordLayoutStyle,
+  {
+    background: colorVars.gold3,
+    opacity: '0.8',
+  },
+]);

--- a/frontend/techpick/src/components/FolderTree/MoveFolderToRecycleBinDialog.tsx
+++ b/frontend/techpick/src/components/FolderTree/MoveFolderToRecycleBinDialog.tsx
@@ -6,6 +6,7 @@ import * as Dialog from '@radix-ui/react-dialog';
 import { XIcon } from 'lucide-react';
 import { ROUTES } from '@/constants';
 import { useTreeStore } from '@/stores';
+import { dialogOverlayStyle } from '@/styles/dialogStyle.css';
 import {
   moveRecycleBinCancelButtonStyle,
   moveRecycleBinConfirmButtonStyle,
@@ -13,7 +14,6 @@ import {
   moveRecycleBinDialogDescriptionStyle,
   moveRecycleBinDialogShareFolderWarningDescriptionStyle,
   moveRecycleBinDialogTitleStyle,
-  moveRecycleBinOverlayStyle,
   moveRecycleDialogContent,
 } from './moveFolderToRecycleBinDialog.css';
 
@@ -52,7 +52,7 @@ export function MoveFolderToRecycleBinDialog({
   return (
     <Dialog.Root open={isOpen} onOpenChange={onOpenChange}>
       <Dialog.Portal>
-        <Dialog.Overlay className={moveRecycleBinOverlayStyle} />
+        <Dialog.Overlay className={dialogOverlayStyle} />
         <Dialog.Content className={moveRecycleDialogContent}>
           <div>
             <Dialog.Title className={moveRecycleBinDialogTitleStyle}>

--- a/frontend/techpick/src/components/FolderTree/ShareFolderDialog.tsx
+++ b/frontend/techpick/src/components/FolderTree/ShareFolderDialog.tsx
@@ -4,9 +4,21 @@ import { useState } from 'react';
 import Link from 'next/link';
 import * as DialogPrimitive from '@radix-ui/react-dialog';
 import { Settings } from 'lucide-react';
+import { dialogOverlayStyle } from '@/styles/dialogStyle.css';
 import { Popover, PopoverContent, PopoverTrigger } from '@/ui/Popover/Popover';
 import { handleShareFolderLinkCopy } from '@/utils/handleShareFolderLinkCopy';
-import * as styles from './shareFolderDialog.css';
+import {
+  dialogContent,
+  dialogTitle,
+  dialogDescription,
+  myLinkPageLinkText,
+  linkContent,
+  icon,
+  sharedFolderLink,
+  copyButton,
+  popoverStyle,
+  closeIcon,
+} from './shareFolderDialog.css';
 
 export default function ShareFolderDialog({
   uuid,
@@ -23,15 +35,15 @@ export default function ShareFolderDialog({
   return (
     <DialogPrimitive.Root open={isOpen} onOpenChange={onOpenChange}>
       <DialogPrimitive.Portal>
-        <DialogPrimitive.Overlay className={styles.dialogOverlay} />
-        <DialogPrimitive.Content className={styles.dialogContent}>
-          <DialogPrimitive.Title className={styles.dialogTitle}>
+        <DialogPrimitive.Overlay className={dialogOverlayStyle} />
+        <DialogPrimitive.Content className={dialogContent}>
+          <DialogPrimitive.Title className={dialogTitle}>
             폴더가 공유되었습니다.
           </DialogPrimitive.Title>
-          <DialogPrimitive.Description className={styles.dialogDescription}>
-            <Link href={`/mypage`} className={styles.myLinkPageLinkText}>
-              <span className={styles.linkContent} onClick={onOpenChange}>
-                <Settings className={styles.icon} size={14} />
+          <DialogPrimitive.Description className={dialogDescription}>
+            <Link href={`/mypage`} className={myLinkPageLinkText}>
+              <span className={linkContent} onClick={onOpenChange}>
+                <Settings className={icon} size={14} />
                 내설정
               </span>
             </Link>
@@ -46,7 +58,7 @@ export default function ShareFolderDialog({
             }}
           >
             <div
-              className={styles.sharedFolderLink}
+              className={sharedFolderLink}
               id="shared-folder-link"
               title={shareFolderLink}
             >
@@ -55,21 +67,16 @@ export default function ShareFolderDialog({
             <Popover open={showPopover}>
               <PopoverTrigger asChild>
                 <button
-                  className={styles.copyButton}
+                  className={copyButton}
                   onClick={() => handleShareFolderLinkCopy(handleShowPopver)}
                 >
                   Copy
                 </button>
               </PopoverTrigger>
-              <PopoverContent className={styles.popoverStyle}>
-                Copied
-              </PopoverContent>
+              <PopoverContent className={popoverStyle}>Copied</PopoverContent>
             </Popover>
           </div>
-          <DialogPrimitive.Close
-            className={styles.closeIcon}
-            onClick={onOpenChange}
-          >
+          <DialogPrimitive.Close className={closeIcon} onClick={onOpenChange}>
             ×
           </DialogPrimitive.Close>
         </DialogPrimitive.Content>

--- a/frontend/techpick/src/components/FolderTree/moveFolderToRecycleBinDialog.css.ts
+++ b/frontend/techpick/src/components/FolderTree/moveFolderToRecycleBinDialog.css.ts
@@ -1,46 +1,20 @@
-import { keyframes, style } from '@vanilla-extract/css';
+import { style } from '@vanilla-extract/css';
 import { colorVars } from 'techpick-shared';
+import { dialogContentStyle } from '@/styles/dialogStyle.css';
 import { redOutlineButtonStyle } from '@/styles/redButtonStyle.css';
 import { sandOutlineButtonStyle } from '@/styles/sandButtonStyle.css';
 
-const contentShow = keyframes({
-  from: {
-    opacity: '0',
-    transform: 'translate(-50%, -48%) scale(0.96)',
+export const moveRecycleDialogContent = style([
+  dialogContentStyle,
+  {
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'space-between',
+    width: 'auto',
+    height: 'auto',
+    padding: '24px',
   },
-  to: {
-    opacity: '1',
-    transform: 'translate(-50%, -50%) scale(1)',
-  },
-});
-
-export const moveRecycleBinOverlayStyle = style({
-  position: 'fixed',
-  inset: '0',
-  animation: ' overlayShow 150ms cubic-bezier(0.16, 1, 0.3, 1)',
-  backgroundColor: colorVars.sand8,
-  opacity: 0.5,
-});
-
-export const moveRecycleDialogContent = style({
-  position: 'fixed',
-  top: '50%',
-  left: '50%',
-  transform: 'translate(-50%, -50%)',
-  display: 'flex',
-  flexDirection: 'column',
-  justifyContent: 'space-between',
-  width: 'auto',
-  height: 'auto',
-  borderRadius: '8px',
-  boxShadow: `
-    hsl(206 22% 7% / 35%) 0px 10px 38px -10px,
-    hsl(206 22% 7% / 20%) 0px 10px 20px -15px
-  `,
-  padding: '24px',
-  backgroundColor: colorVars.gold4,
-  animation: `${contentShow} 150ms cubic-bezier(0.16, 1, 0.3, 1)`,
-});
+]);
 
 export const moveRecycleBinDialogTitleStyle = style({
   display: 'block',

--- a/frontend/techpick/src/components/FolderTree/moveFolderToRecycleBinDialog.css.ts
+++ b/frontend/techpick/src/components/FolderTree/moveFolderToRecycleBinDialog.css.ts
@@ -1,5 +1,7 @@
 import { keyframes, style } from '@vanilla-extract/css';
 import { colorVars } from 'techpick-shared';
+import { redOutlineButtonStyle } from '@/styles/redButtonStyle.css';
+import { sandOutlineButtonStyle } from '@/styles/sandButtonStyle.css';
 
 const contentShow = keyframes({
   from: {
@@ -66,37 +68,19 @@ export const moveRecycleBinDialogCloseButton = style({
   cursor: 'pointer',
 });
 
-export const moveRecycleBinConfirmButtonStyle = style({
-  width: '100%',
-  height: '32px',
-  border: '1px solid',
-  borderColor: colorVars.red8,
-  borderRadius: '4px',
-  transition: 'background-color 0.3s ease',
-  color: colorVars.red11,
-  cursor: 'pointer',
-
-  selectors: {
-    '&:hover, &:focus': {
-      backgroundColor: colorVars.red3,
-    },
+export const moveRecycleBinConfirmButtonStyle = style([
+  redOutlineButtonStyle,
+  {
+    width: '100%',
+    height: '32px',
   },
-});
+]);
 
-export const moveRecycleBinCancelButtonStyle = style({
-  marginTop: '8px',
-  width: '100%',
-  height: '32px',
-  border: '1px solid',
-  borderColor: colorVars.sand8,
-  borderRadius: '4px',
-  transition: 'background-color 0.3s ease',
-  color: colorVars.sand11,
-  cursor: 'pointer',
-
-  selectors: {
-    '&:hover, &:focus': {
-      backgroundColor: colorVars.sand3,
-    },
+export const moveRecycleBinCancelButtonStyle = style([
+  sandOutlineButtonStyle,
+  {
+    marginTop: '8px',
+    width: '100%',
+    height: '32px',
   },
-});
+]);

--- a/frontend/techpick/src/components/FolderTree/shareFolderDialog.css.ts
+++ b/frontend/techpick/src/components/FolderTree/shareFolderDialog.css.ts
@@ -1,46 +1,19 @@
-import { keyframes, style } from '@vanilla-extract/css';
+import { style } from '@vanilla-extract/css';
 import { colorVars } from 'techpick-shared';
-
-const contentShow = keyframes({
-  from: {
-    opacity: '0',
-    transform: 'translate(-50%, -48%) scale(0.96)',
-  },
-  to: {
-    opacity: '1',
-    transform: 'translate(-50%, -50%) scale(1)',
-  },
-});
+import { dialogContentStyle } from '@/styles/dialogStyle.css';
 
 /* --------------- Dialog --------------- */
-export const dialogOverlay = style({
-  position: 'fixed',
-  inset: '0',
-  animation: ' overlayShow 150ms cubic-bezier(0.16, 1, 0.3, 1)',
-  backgroundColor: colorVars.sand8,
-  opacity: 0.5,
-});
 
-export const dialogContent = style({
-  position: 'fixed',
-  top: '50%',
-  left: '50%',
-  transform: 'translate(-50%, -50%)',
-  display: 'flex',
-  flexDirection: 'column',
-  justifyContent: 'space-between',
-  // width: '320px',
-  // height: '160px',
-  gap: '12px',
-  borderRadius: '8px',
-  boxShadow: `
-    hsl(206 22% 7% / 35%) 0px 10px 38px -10px,
-    hsl(206 22% 7% / 20%) 0px 10px 20px -15px
-  `,
-  padding: '16px',
-  backgroundColor: colorVars.gold4,
-  animation: `${contentShow} 150ms cubic-bezier(0.16, 1, 0.3, 1)`,
-});
+export const dialogContent = style([
+  dialogContentStyle,
+  {
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'space-between',
+    gap: '12px',
+    padding: '16px',
+  },
+]);
 
 export const dialogTitle = style({
   fontWeight: 'normal',

--- a/frontend/techpick/src/components/ImportBookmarkDialog.tsx
+++ b/frontend/techpick/src/components/ImportBookmarkDialog.tsx
@@ -7,10 +7,10 @@ import { XIcon } from 'lucide-react';
 import { useDropzone } from 'react-dropzone';
 import { uploadBookmark } from '@/apis/bookmark';
 import { useTreeStore } from '@/stores';
+import { dialogOverlayStyle } from '@/styles/dialogStyle.css';
 import { notifyError, notifySuccess } from '@/utils';
 import {
   importBookmarkDialogButtonStyle,
-  overlayStyle,
   dialogContent,
   dropzoneStyle,
   closeButtonStyle,
@@ -80,7 +80,7 @@ export function ImportBookmarkDialog() {
         </button>
       </Dialog.Trigger>
       <Dialog.Portal>
-        <Dialog.Overlay className={overlayStyle} />
+        <Dialog.Overlay className={dialogOverlayStyle} />
         <Dialog.Content className={dialogContent}>
           <VisuallyHidden.Root>
             <Dialog.Title className="DialogTitle">북마크 가져오기</Dialog.Title>

--- a/frontend/techpick/src/components/MyPage/myPageShareFolderField.css.ts
+++ b/frontend/techpick/src/components/MyPage/myPageShareFolderField.css.ts
@@ -1,5 +1,6 @@
 import { style } from '@vanilla-extract/css';
-import { colorVars, fontSize } from 'techpick-shared';
+import { fontSize } from 'techpick-shared';
+import { redOutlineButtonStyle } from '@/styles/redButtonStyle.css';
 
 export const myPageContentContainer = style({
   display: 'grid',
@@ -16,16 +17,10 @@ export const cell = style({
   padding: '0 8px',
 });
 
-export const cancelButton = style({
-  minWidth: '70px',
-  padding: '4px',
-  border: '1px solid',
-  borderColor: colorVars.red8,
-  borderRadius: '4px',
-  transition: 'background-color 0.3s ease',
-  color: colorVars.red11,
-  cursor: 'pointer',
-  ':hover': {
-    backgroundColor: colorVars.red3,
+export const cancelButton = style([
+  redOutlineButtonStyle,
+  {
+    minWidth: '70px',
+    padding: '4px',
   },
-});
+]);

--- a/frontend/techpick/src/components/PickTagPicker/DeleteTagDialog.css.ts
+++ b/frontend/techpick/src/components/PickTagPicker/DeleteTagDialog.css.ts
@@ -1,5 +1,7 @@
 import { style } from '@vanilla-extract/css';
 import { colorVars, zIndex } from 'techpick-shared';
+import { redOutlineButtonStyle } from '@/styles/redButtonStyle.css';
+import { sandOutlineButtonStyle } from '@/styles/sandButtonStyle.css';
 
 export const dialogContentStyle = style({
   position: 'absolute',
@@ -32,42 +34,18 @@ export const dialogOverlayStyle = style({
   opacity: 0.5,
 });
 
-export const deleteTagButtonStyle = style({
-  width: '100%',
-  border: '1px solid',
-  borderColor: colorVars.red8,
-  borderRadius: '4px',
-  transition: 'background-color 0.3s ease',
-  color: colorVars.red11,
-  cursor: 'pointer',
-  fontSize: '14px',
-
-  ':hover': {
-    backgroundColor: colorVars.red3,
+export const deleteTagButtonStyle = style([
+  redOutlineButtonStyle,
+  {
+    width: '100%',
+    fontSize: '14px',
   },
+]);
 
-  ':focus': {
-    backgroundColor: colorVars.red3,
-    outline: 'none',
+export const deleteTagCancelButtonStyle = style([
+  sandOutlineButtonStyle,
+  {
+    width: '100%',
+    fontSize: '14px',
   },
-});
-
-export const deleteTagCancelButtonStyle = style({
-  width: '100%',
-  border: '1px solid',
-  borderColor: colorVars.sand8,
-  borderRadius: '4px',
-  transition: 'background-color 0.3s ease',
-  color: colorVars.sand11,
-  cursor: 'pointer',
-  fontSize: '14px',
-
-  ':hover': {
-    backgroundColor: colorVars.sand3,
-  },
-
-  ':focus': {
-    backgroundColor: colorVars.sand3,
-    outline: 'none',
-  },
-});
+]);

--- a/frontend/techpick/src/components/PickTagPicker/DeleteTagDialog.css.ts
+++ b/frontend/techpick/src/components/PickTagPicker/DeleteTagDialog.css.ts
@@ -1,38 +1,32 @@
 import { style } from '@vanilla-extract/css';
-import { colorVars, zIndex } from 'techpick-shared';
+import { zIndex } from 'techpick-shared';
+import {
+  dialogOverlayStyle as baseDialogOverlayStyle,
+  dialogContentStyle as baseDialogContentStyle,
+} from '@/styles/dialogStyle.css';
 import { redOutlineButtonStyle } from '@/styles/redButtonStyle.css';
 import { sandOutlineButtonStyle } from '@/styles/sandButtonStyle.css';
 
-export const dialogContentStyle = style({
-  position: 'absolute',
-  margin: 'auto',
-  top: '50%',
-  left: '50%',
-  transform: 'translate(-50%, -50%)',
-  zIndex: zIndex.level5,
-  display: 'flex',
-  flexDirection: 'column',
-  justifyContent: 'center',
-  gap: '8px',
-  minWidth: '216px',
-  border: `1px solid ${colorVars.color.tagBorder}`,
-  borderRadius: '4px',
-  padding: '16px',
-  backgroundColor: colorVars.gold4,
-  boxShadow: `
-  hsl(206 22% 7% / 35%) 0px 10px 38px -10px,
-  hsl(206 22% 7% / 20%) 0px 10px 20px -15px
-`,
-});
+export const dialogContentStyle = style([
+  baseDialogContentStyle,
+  {
+    margin: 'auto',
+    zIndex: zIndex.level5,
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'center',
+    gap: '8px',
+    minWidth: '216px',
+    padding: '16px',
+  },
+]);
 
-export const dialogOverlayStyle = style({
-  zIndex: zIndex.level4,
-  position: 'fixed',
-  inset: '0',
-  animation: ' overlayShow 150ms cubic-bezier(0.16, 1, 0.3, 1)',
-  backgroundColor: colorVars.sand8,
-  opacity: 0.5,
-});
+export const dialogOverlayStyle = style([
+  baseDialogOverlayStyle,
+  {
+    zIndex: zIndex.level4,
+  },
+]);
 
 export const deleteTagButtonStyle = style([
   redOutlineButtonStyle,

--- a/frontend/techpick/src/components/PickTagPicker/PickTagAutocompleteDialog.tsx
+++ b/frontend/techpick/src/components/PickTagPicker/PickTagAutocompleteDialog.tsx
@@ -18,6 +18,7 @@ import { DeleteTagDialog } from './DeleteTagDialog';
 import { DeselectTagButton } from './DeselectTagButton';
 import { SelectedTagItem } from '../SelectedTagItem';
 import {
+  dialogOverlayStyle,
   tagDialogPortalLayout,
   commandInputStyle,
   tagListItemStyle,
@@ -154,7 +155,7 @@ export function PickTagAutocompleteDialog({
       }}
     >
       <Dialog.Portal container={container}>
-        <Dialog.Overlay style={{ zIndex: 1 }} />
+        <Dialog.Overlay className={dialogOverlayStyle} />
         <Dialog.Content
           style={{ ...floatingStyles }}
           ref={setFloating}

--- a/frontend/techpick/src/components/PickTagPicker/pickTagAutocompleteDialog.css.ts
+++ b/frontend/techpick/src/components/PickTagPicker/pickTagAutocompleteDialog.css.ts
@@ -79,3 +79,7 @@ export const tagCreateTextStyle = style({
   fontSize: '14px',
   color: color.font,
 });
+
+export const dialogOverlayStyle = style({
+  zIndex: 1,
+});

--- a/frontend/techpick/src/components/PickTagPicker/showDeleteTagDialogButton.css.ts
+++ b/frontend/techpick/src/components/PickTagPicker/showDeleteTagDialogButton.css.ts
@@ -1,20 +1,9 @@
 import { style } from '@vanilla-extract/css';
-import { colorVars } from 'techpick-shared';
+import { redOutlineButtonStyle } from '@/styles/redButtonStyle.css';
 
-export const deleteTagDialogButtonStyle = style({
-  border: '1px solid',
-  borderColor: colorVars.red8,
-  borderRadius: '4px',
-  transition: 'background-color 0.3s ease',
-  color: colorVars.red11,
-  cursor: 'pointer',
-  fontSize: '14px',
-
-  ':hover': {
-    backgroundColor: colorVars.red3,
+export const deleteTagDialogButtonStyle = style([
+  redOutlineButtonStyle,
+  {
+    fontSize: '14px',
   },
-
-  ':focus': {
-    backgroundColor: colorVars.red3,
-  },
-});
+]);

--- a/frontend/techpick/src/components/Search2/SearchDialog.tsx
+++ b/frontend/techpick/src/components/Search2/SearchDialog.tsx
@@ -3,10 +3,15 @@ import * as DialogPrimitive from '@radix-ui/react-dialog';
 import { VisuallyHidden } from '@radix-ui/react-visually-hidden';
 import { OPEN_SEARCH_DIALOG_EVENT } from '@/constants';
 import { useSearchPickStore } from '@/stores/searchPickStore';
+import { dialogOverlayStyle } from '@/styles/dialogStyle.css';
 import { eventEmitter } from '@/utils/eventEmitter';
 import FilterContainer from './FilterContainer';
 import HoverCard from './HoverCard';
-import * as styles from './searchDialog.css';
+import {
+  dialogContent,
+  searchBar,
+  searchListContainer,
+} from './searchDialog.css';
 import { SearchInfiniteScrollList } from './SearchInfiniteScrollList';
 import SearchInput from './SearchInput';
 
@@ -39,16 +44,16 @@ export default function SearchDialog({
   return (
     <DialogPrimitive.Root open={isOpen} onOpenChange={handleOnClose}>
       <DialogPrimitive.Portal>
-        <DialogPrimitive.Overlay className={styles.dialogOverlay} />
-        <DialogPrimitive.Content className={styles.dialogContent}>
+        <DialogPrimitive.Overlay className={dialogOverlayStyle} />
+        <DialogPrimitive.Content className={dialogContent}>
           <DialogPrimitive.Title>
             <VisuallyHidden>Pick Search</VisuallyHidden>
           </DialogPrimitive.Title>
-          <div className={styles.searchBar}>
+          <div className={searchBar}>
             <SearchInput />
           </div>
           <FilterContainer />
-          <div className={styles.searchListContainer}>
+          <div className={searchListContainer}>
             <SearchInfiniteScrollList onClose={handleOnClose} />
             <HoverCard />
           </div>

--- a/frontend/techpick/src/components/Search2/searchDialog.css.ts
+++ b/frontend/techpick/src/components/Search2/searchDialog.css.ts
@@ -1,24 +1,17 @@
 import { style } from '@vanilla-extract/css';
 import { colorVars } from 'techpick-shared';
+import { dialogContentStyle } from '@/styles/dialogStyle.css';
 
-export const dialogOverlay = style({
-  backgroundColor: 'rgba(0, 0, 0, 0.4)',
-  position: 'fixed',
-  inset: 0,
-});
-
-export const dialogContent = style({
-  background: 'white',
-  borderRadius: '8px',
-  padding: '16px',
-  width: '100%',
-  minWidth: '300px',
-  maxWidth: '800px',
-  top: '50%',
-  left: '50%',
-  transform: 'translate(-50%, -50%)',
-  position: 'fixed',
-});
+export const dialogContent = style([
+  dialogContentStyle,
+  {
+    background: 'white',
+    padding: '16px',
+    width: '100%',
+    minWidth: '300px',
+    maxWidth: '800px',
+  },
+]);
 
 export const searchListContainer = style({
   display: 'flex',

--- a/frontend/techpick/src/components/TutorialDialog.tsx
+++ b/frontend/techpick/src/components/TutorialDialog.tsx
@@ -7,11 +7,11 @@ import * as Tabs from '@radix-ui/react-tabs';
 import * as VisuallyHidden from '@radix-ui/react-visually-hidden';
 import { IS_TUTORIAL_SEEN_LOCAL_STORAGE_KEY } from '@/constants';
 import { useDisclosure, useLocalStorage } from '@/hooks';
+import { dialogOverlayStyle } from '@/styles/dialogStyle.css';
 import { Gap } from './Gap';
 import {
   dialogCloseButtonStyle,
   dialogContent,
-  overlayStyle,
   pointTextStyle,
   tabContentDescriptionStyle,
   tabContentStyle,
@@ -62,7 +62,7 @@ export function TutorialDialog() {
   return (
     <Dialog.Root open={isOpen} modal>
       <Dialog.Portal>
-        <Dialog.Overlay className={overlayStyle} />
+        <Dialog.Overlay className={dialogOverlayStyle} />
         <Dialog.Content className={dialogContent}>
           <VisuallyHidden.Root>
             <Dialog.Title>튜토리얼</Dialog.Title>

--- a/frontend/techpick/src/components/importBookmarkDialog.css.ts
+++ b/frontend/techpick/src/components/importBookmarkDialog.css.ts
@@ -1,6 +1,7 @@
 import { keyframes, style } from '@vanilla-extract/css';
 import { colorVars } from 'techpick-shared';
 import { goldOutlineButtonStyle } from '@/styles/goldButtonStyle.css';
+import { greenOutlineButtonStyle } from '@/styles/greenButtonStyle.css';
 
 export const importBookmarkDialogButtonStyle = style([
   goldOutlineButtonStyle,
@@ -49,26 +50,6 @@ export const dialogContent = style({
   animation: `${contentShow} 150ms cubic-bezier(0.16, 1, 0.3, 1)`,
 });
 
-export const dialogCloseButtonStyle = style({
-  width: '56px',
-  height: '32px',
-  border: '1px solid',
-  borderColor: colorVars.orange8,
-  borderRadius: '4px',
-  backgroundColor: colorVars.orange1,
-  color: colorVars.primary,
-  cursor: 'pointer',
-  transition: 'background-color 0.3s ease',
-
-  ':hover': {
-    backgroundColor: colorVars.orange3,
-  },
-
-  ':focus': {
-    backgroundColor: colorVars.orange3,
-  },
-});
-
 export const dropzoneStyle = style({
   display: 'flex',
   justifyContent: 'center',
@@ -90,23 +71,14 @@ export const closeButtonStyle = style({
   cursor: 'pointer',
 });
 
-export const submitButtonStyle = style({
-  marginTop: '8px',
-  width: '100%',
-  height: '32px',
-  border: '1px solid',
-  borderColor: colorVars.green8,
-  borderRadius: '4px',
-  transition: 'background-color 0.3s ease',
-  color: colorVars.green11,
-  cursor: 'pointer',
-
-  selectors: {
-    '&:hover, &:focus': {
-      backgroundColor: colorVars.green3,
-    },
+export const submitButtonStyle = style([
+  greenOutlineButtonStyle,
+  {
+    marginTop: '8px',
+    width: '100%',
+    height: '32px',
   },
-});
+]);
 
 export const dragInfoTextStyle = style({
   whiteSpace: 'pre-wrap',

--- a/frontend/techpick/src/components/importBookmarkDialog.css.ts
+++ b/frontend/techpick/src/components/importBookmarkDialog.css.ts
@@ -1,5 +1,6 @@
-import { keyframes, style } from '@vanilla-extract/css';
+import { style } from '@vanilla-extract/css';
 import { colorVars } from 'techpick-shared';
+import { dialogContentStyle } from '@/styles/dialogStyle.css';
 import { goldOutlineButtonStyle } from '@/styles/goldButtonStyle.css';
 import { greenOutlineButtonStyle } from '@/styles/greenButtonStyle.css';
 
@@ -11,44 +12,17 @@ export const importBookmarkDialogButtonStyle = style([
   },
 ]);
 
-const contentShow = keyframes({
-  from: {
-    opacity: '0',
-    transform: 'translate(-50%, -48%) scale(0.96)',
+export const dialogContent = style([
+  dialogContentStyle,
+  {
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'space-between',
+    width: 'auto',
+    height: 'auto',
+    padding: '24px',
   },
-  to: {
-    opacity: '1',
-    transform: 'translate(-50%, -50%) scale(1)',
-  },
-});
-
-export const overlayStyle = style({
-  position: 'fixed',
-  inset: '0',
-  animation: 'overlayShow 150ms cubic-bezier(0.16, 1, 0.3, 1)',
-  backgroundColor: colorVars.sand8,
-  opacity: 0.5,
-});
-
-export const dialogContent = style({
-  position: 'fixed',
-  top: '50%',
-  left: '50%',
-  transform: 'translate(-50%, -50%)',
-  display: 'flex',
-  flexDirection: 'column',
-  justifyContent: 'space-between',
-  width: 'auto',
-  height: 'auto',
-  borderRadius: '8px',
-  boxShadow: `
-    hsl(206 22% 7% / 35%) 0px 10px 38px -10px,
-    hsl(206 22% 7% / 20%) 0px 10px 20px -15px
-  `,
-  padding: '24px',
-  backgroundColor: colorVars.gold4,
-  animation: `${contentShow} 150ms cubic-bezier(0.16, 1, 0.3, 1)`,
-});
+]);
 
 export const dropzoneStyle = style({
   display: 'flex',

--- a/frontend/techpick/src/components/importBookmarkDialog.css.ts
+++ b/frontend/techpick/src/components/importBookmarkDialog.css.ts
@@ -1,24 +1,14 @@
 import { keyframes, style } from '@vanilla-extract/css';
 import { colorVars } from 'techpick-shared';
+import { goldOutlineButtonStyle } from '@/styles/goldButtonStyle.css';
 
-export const importBookmarkDialogButtonStyle = style({
-  width: '120px',
-  height: '32px',
-  border: '1px solid',
-  borderColor: colorVars.gold8,
-  borderRadius: '4px',
-  transition: 'background-color 0.3s ease',
-  color: colorVars.gold11,
-  cursor: 'pointer',
-
-  ':hover': {
-    backgroundColor: colorVars.gold3,
+export const importBookmarkDialogButtonStyle = style([
+  goldOutlineButtonStyle,
+  {
+    width: '120px',
+    height: '32px',
   },
-
-  ':focus': {
-    backgroundColor: colorVars.gold3,
-  },
-});
+]);
 
 const contentShow = keyframes({
   from: {

--- a/frontend/techpick/src/components/tutorialDialog.css.ts
+++ b/frontend/techpick/src/components/tutorialDialog.css.ts
@@ -1,5 +1,6 @@
 import { keyframes, style } from '@vanilla-extract/css';
 import { colorVars } from 'techpick-shared';
+import { orangeOutlineButtonStyle } from '@/styles/orangeButtonStyle.css';
 
 const contentShow = keyframes({
   from: {
@@ -46,31 +47,19 @@ export const tabListStyle = style({
   right: '0px',
 });
 
-export const tabTriggerButtonStyle = style({
-  width: '56px',
-  height: '32px',
-  border: '1px solid',
-  borderColor: colorVars.orange8,
-  borderRadius: '4px',
-  backgroundColor: colorVars.orange1,
-  color: colorVars.primary,
-  cursor: 'pointer',
-  transition: 'background-color 0.3s ease',
+export const tabTriggerButtonStyle = style([
+  orangeOutlineButtonStyle,
+  {
+    width: '56px',
+    height: '32px',
 
-  ':hover': {
-    backgroundColor: colorVars.orange3,
-  },
-
-  ':focus': {
-    backgroundColor: colorVars.orange3,
-  },
-
-  selectors: {
-    '&[data-state="open"]': {
-      backgroundColor: colorVars.orange3,
+    selectors: {
+      '&[data-state="open"]': {
+        backgroundColor: colorVars.orange3,
+      },
     },
   },
-});
+]);
 
 export const tabContentDescriptionStyle = style({
   height: '32px',
@@ -82,25 +71,13 @@ export const tabContentDescriptionStyle = style({
 
 export const pointTextStyle = style({ color: colorVars.primary });
 
-export const dialogCloseButtonStyle = style({
-  width: '56px',
-  height: '32px',
-  border: '1px solid',
-  borderColor: colorVars.orange8,
-  borderRadius: '4px',
-  backgroundColor: colorVars.orange1,
-  color: colorVars.primary,
-  cursor: 'pointer',
-  transition: 'background-color 0.3s ease',
-
-  ':hover': {
-    backgroundColor: colorVars.orange3,
+export const dialogCloseButtonStyle = style([
+  orangeOutlineButtonStyle,
+  {
+    width: '56px',
+    height: '32px',
   },
-
-  ':focus': {
-    backgroundColor: colorVars.orange3,
-  },
-});
+]);
 
 export const tabContentStyle = style({
   position: 'relative',

--- a/frontend/techpick/src/components/tutorialDialog.css.ts
+++ b/frontend/techpick/src/components/tutorialDialog.css.ts
@@ -1,45 +1,19 @@
-import { keyframes, style } from '@vanilla-extract/css';
+import { style } from '@vanilla-extract/css';
 import { colorVars } from 'techpick-shared';
+import { dialogContentStyle } from '@/styles/dialogStyle.css';
 import { orangeOutlineButtonStyle } from '@/styles/orangeButtonStyle.css';
 
-const contentShow = keyframes({
-  from: {
-    opacity: '0',
-    transform: 'translate(-50%, -48%) scale(0.96)',
+export const dialogContent = style([
+  dialogContentStyle,
+  {
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'space-between',
+    width: 'auto',
+    height: 'auto',
+    padding: '24px',
   },
-  to: {
-    opacity: '1',
-    transform: 'translate(-50%, -50%) scale(1)',
-  },
-});
-
-export const overlayStyle = style({
-  position: 'fixed',
-  inset: '0',
-  animation: 'overlayShow 150ms cubic-bezier(0.16, 1, 0.3, 1)',
-  backgroundColor: colorVars.sand8,
-  opacity: 0.5,
-});
-
-export const dialogContent = style({
-  position: 'fixed',
-  top: '50%',
-  left: '50%',
-  transform: 'translate(-50%, -50%)',
-  display: 'flex',
-  flexDirection: 'column',
-  justifyContent: 'space-between',
-  width: 'auto',
-  height: 'auto',
-  borderRadius: '8px',
-  boxShadow: `
-    hsl(206 22% 7% / 35%) 0px 10px 38px -10px,
-    hsl(206 22% 7% / 20%) 0px 10px 20px -15px
-  `,
-  padding: '24px',
-  backgroundColor: colorVars.gold4,
-  animation: `${contentShow} 150ms cubic-bezier(0.16, 1, 0.3, 1)`,
-});
+]);
 
 export const tabListStyle = style({
   position: 'absolute',
@@ -52,7 +26,7 @@ export const tabTriggerButtonStyle = style([
   {
     width: '56px',
     height: '32px',
-
+    backgroundColor: colorVars.orange1,
     selectors: {
       '&[data-state="open"]': {
         backgroundColor: colorVars.orange3,
@@ -74,6 +48,7 @@ export const pointTextStyle = style({ color: colorVars.primary });
 export const dialogCloseButtonStyle = style([
   orangeOutlineButtonStyle,
   {
+    backgroundColor: colorVars.orange1,
     width: '56px',
     height: '32px',
   },

--- a/frontend/techpick/src/styles/baseButtonStyle.css.ts
+++ b/frontend/techpick/src/styles/baseButtonStyle.css.ts
@@ -6,8 +6,3 @@ export const baseButtonStyle = style({
   cursor: 'pointer',
   outline: 'none',
 });
-
-export const outlineButtonStyle = style({
-  border: '1px solid',
-  backgroundColor: 'transparent',
-});

--- a/frontend/techpick/src/styles/baseButtonStyle.css.ts
+++ b/frontend/techpick/src/styles/baseButtonStyle.css.ts
@@ -1,0 +1,13 @@
+import { style } from '@vanilla-extract/css';
+
+export const baseButtonStyle = style({
+  borderRadius: '4px',
+  transition: 'all 0.3s ease',
+  cursor: 'pointer',
+  outline: 'none',
+});
+
+export const outlineButtonStyle = style({
+  border: '1px solid',
+  backgroundColor: 'transparent',
+});

--- a/frontend/techpick/src/styles/dialogStyle.css.ts
+++ b/frontend/techpick/src/styles/dialogStyle.css.ts
@@ -1,0 +1,37 @@
+import { keyframes, style } from '@vanilla-extract/css';
+import { colorVars } from 'techpick-shared';
+
+const contentShow = keyframes({
+  from: {
+    opacity: '0',
+    transform: 'translate(-50%, -48%) scale(0.96)',
+  },
+  to: {
+    opacity: '1',
+    transform: 'translate(-50%, -50%) scale(1)',
+  },
+});
+
+export const dialogOverlayStyle = style({
+  position: 'fixed',
+  inset: '0',
+  backgroundColor: colorVars.sand8,
+  opacity: 0.5,
+});
+
+/**
+ * @description width, height, padding은 직접 설정해야합니다.
+ */
+export const dialogContentStyle = style({
+  position: 'fixed',
+  top: '50%',
+  left: '50%',
+  transform: 'translate(-50%, -50%)',
+  borderRadius: '8px',
+  boxShadow: `
+    hsl(206 22% 7% / 35%) 0px 10px 38px -10px,
+    hsl(206 22% 7% / 20%) 0px 10px 20px -15px
+  `,
+  backgroundColor: colorVars.gold4,
+  animation: `${contentShow} 150ms cubic-bezier(0.16, 1, 0.3, 1)`,
+});

--- a/frontend/techpick/src/styles/goldButtonStyle.css.ts
+++ b/frontend/techpick/src/styles/goldButtonStyle.css.ts
@@ -23,7 +23,7 @@ export const goldOutlineButtonStyle = style([
   outlineButtonStyle,
   {
     borderColor: colorVars.gold7,
-    backgroundColor: 'transparent',
+    backgroundColor: colorVars.gold1,
     color: colorVars.gold11,
     selectors: {
       '&:hover, &:focus': {
@@ -39,7 +39,7 @@ export const goldOutlineButtonStyle = style([
 export const goldGhostButtonStyle = style([
   baseButtonStyle,
   {
-    backgroundColor: 'transparent',
+    backgroundColor: colorVars.gold1,
     color: colorVars.gold11,
     selectors: {
       '&:hover, &:focus': {
@@ -55,7 +55,7 @@ export const goldGhostButtonStyle = style([
 export const goldLinkButtonStyle = style([
   baseButtonStyle,
   {
-    backgroundColor: 'transparent',
+    backgroundColor: colorVars.gold1,
     color: colorVars.gold11,
     selectors: {
       '&:hover, &:focus': {

--- a/frontend/techpick/src/styles/goldButtonStyle.css.ts
+++ b/frontend/techpick/src/styles/goldButtonStyle.css.ts
@@ -1,0 +1,67 @@
+import { style } from '@vanilla-extract/css';
+import { colorVars } from 'techpick-shared';
+import { baseButtonStyle, outlineButtonStyle } from './baseButtonStyle.css';
+
+/**
+ * @description color만 설정했습니다. width, height, padding 등은 직접 설정하셔야합니다.
+ */
+export const goldSolidButtonStyle = style([
+  baseButtonStyle,
+  {
+    backgroundColor: colorVars.gold9,
+    color: 'white',
+    ':hover': { backgroundColor: colorVars.gold10 },
+    ':active': { backgroundColor: colorVars.gold11 },
+  },
+]);
+
+/**
+ * @description color만 설정했습니다. width, height, padding 등은 직접 설정하셔야합니다.
+ */
+export const goldOutlineButtonStyle = style([
+  baseButtonStyle,
+  outlineButtonStyle,
+  {
+    borderColor: colorVars.gold7,
+    backgroundColor: 'transparent',
+    color: colorVars.gold11,
+    selectors: {
+      '&:hover, &:focus': {
+        backgroundColor: colorVars.gold3,
+      },
+    },
+  },
+]);
+
+/**
+ * @description color만 설정했습니다. width, height, padding 등은 직접 설정하셔야합니다.
+ */
+export const goldGhostButtonStyle = style([
+  baseButtonStyle,
+  {
+    backgroundColor: 'transparent',
+    color: colorVars.gold11,
+    selectors: {
+      '&:hover, &:focus': {
+        backgroundColor: colorVars.gold3,
+      },
+    },
+  },
+]);
+
+/**
+ * @description color만 설정했습니다. width, height, padding 등은 직접 설정하셔야합니다.
+ */
+export const goldLinkButtonStyle = style([
+  baseButtonStyle,
+  {
+    backgroundColor: 'transparent',
+    color: colorVars.gold11,
+    selectors: {
+      '&:hover, &:focus': {
+        backgroundColor: colorVars.gold3,
+        textDecoration: 'underline',
+      },
+    },
+  },
+]);

--- a/frontend/techpick/src/styles/goldButtonStyle.css.ts
+++ b/frontend/techpick/src/styles/goldButtonStyle.css.ts
@@ -23,7 +23,7 @@ export const goldOutlineButtonStyle = style([
   outlineButtonStyle,
   {
     borderColor: colorVars.gold7,
-    backgroundColor: colorVars.gold1,
+    backgroundColor: 'transparent',
     color: colorVars.gold11,
     selectors: {
       '&:hover, &:focus': {
@@ -39,7 +39,7 @@ export const goldOutlineButtonStyle = style([
 export const goldGhostButtonStyle = style([
   baseButtonStyle,
   {
-    backgroundColor: colorVars.gold1,
+    backgroundColor: 'transparent',
     color: colorVars.gold11,
     selectors: {
       '&:hover, &:focus': {
@@ -55,7 +55,7 @@ export const goldGhostButtonStyle = style([
 export const goldLinkButtonStyle = style([
   baseButtonStyle,
   {
-    backgroundColor: colorVars.gold1,
+    backgroundColor: 'transparent',
     color: colorVars.gold11,
     selectors: {
       '&:hover, &:focus': {

--- a/frontend/techpick/src/styles/goldButtonStyle.css.ts
+++ b/frontend/techpick/src/styles/goldButtonStyle.css.ts
@@ -1,6 +1,6 @@
 import { style } from '@vanilla-extract/css';
 import { colorVars } from 'techpick-shared';
-import { baseButtonStyle, outlineButtonStyle } from './baseButtonStyle.css';
+import { baseButtonStyle } from './baseButtonStyle.css';
 
 /**
  * @description color만 설정했습니다. width, height, padding 등은 직접 설정하셔야합니다.
@@ -20,8 +20,8 @@ export const goldSolidButtonStyle = style([
  */
 export const goldOutlineButtonStyle = style([
   baseButtonStyle,
-  outlineButtonStyle,
   {
+    border: '1px solid',
     borderColor: colorVars.gold7,
     backgroundColor: 'transparent',
     color: colorVars.gold11,

--- a/frontend/techpick/src/styles/greenButtonStyle.css.ts
+++ b/frontend/techpick/src/styles/greenButtonStyle.css.ts
@@ -23,7 +23,7 @@ export const greenOutlineButtonStyle = style([
   outlineButtonStyle,
   {
     borderColor: colorVars.green7,
-    backgroundColor: 'transparent',
+    backgroundColor: colorVars.gold1,
     color: colorVars.green11,
     selectors: {
       '&:hover, &:focus': {
@@ -39,7 +39,7 @@ export const greenOutlineButtonStyle = style([
 export const greenGhostButtonStyle = style([
   baseButtonStyle,
   {
-    backgroundColor: 'transparent',
+    backgroundColor: colorVars.gold1,
     color: colorVars.green11,
     selectors: {
       '&:hover, &:focus': {
@@ -55,7 +55,7 @@ export const greenGhostButtonStyle = style([
 export const greenLinkButtonStyle = style([
   baseButtonStyle,
   {
-    backgroundColor: 'transparent',
+    backgroundColor: colorVars.gold1,
     color: colorVars.green11,
     selectors: {
       '&:hover, &:focus': {

--- a/frontend/techpick/src/styles/greenButtonStyle.css.ts
+++ b/frontend/techpick/src/styles/greenButtonStyle.css.ts
@@ -1,0 +1,67 @@
+import { style } from '@vanilla-extract/css';
+import { colorVars } from 'techpick-shared';
+import { baseButtonStyle, outlineButtonStyle } from './baseButtonStyle.css';
+
+/**
+ * @description color만 설정했습니다. width, height, padding 등은 직접 설정하셔야합니다.
+ */
+export const greenSolidButtonStyle = style([
+  baseButtonStyle,
+  {
+    backgroundColor: colorVars.green9,
+    color: 'white',
+    ':hover': { backgroundColor: colorVars.green10 },
+    ':active': { backgroundColor: colorVars.green11 },
+  },
+]);
+
+/**
+ * @description color만 설정했습니다. width, height, padding 등은 직접 설정하셔야합니다.
+ */
+export const greenOutlineButtonStyle = style([
+  baseButtonStyle,
+  outlineButtonStyle,
+  {
+    borderColor: colorVars.green7,
+    backgroundColor: 'transparent',
+    color: colorVars.green11,
+    selectors: {
+      '&:hover, &:focus': {
+        backgroundColor: colorVars.green3,
+      },
+    },
+  },
+]);
+
+/**
+ * @description color만 설정했습니다. width, height, padding 등은 직접 설정하셔야합니다.
+ */
+export const greenGhostButtonStyle = style([
+  baseButtonStyle,
+  {
+    backgroundColor: 'transparent',
+    color: colorVars.green11,
+    selectors: {
+      '&:hover, &:focus': {
+        backgroundColor: colorVars.green3,
+      },
+    },
+  },
+]);
+
+/**
+ * @description color만 설정했습니다. width, height, padding 등은 직접 설정하셔야합니다.
+ */
+export const greenLinkButtonStyle = style([
+  baseButtonStyle,
+  {
+    backgroundColor: 'transparent',
+    color: colorVars.green11,
+    selectors: {
+      '&:hover, &:focus': {
+        backgroundColor: colorVars.green3,
+        textDecoration: 'underline',
+      },
+    },
+  },
+]);

--- a/frontend/techpick/src/styles/greenButtonStyle.css.ts
+++ b/frontend/techpick/src/styles/greenButtonStyle.css.ts
@@ -23,7 +23,7 @@ export const greenOutlineButtonStyle = style([
   outlineButtonStyle,
   {
     borderColor: colorVars.green7,
-    backgroundColor: colorVars.gold1,
+    backgroundColor: 'transparent',
     color: colorVars.green11,
     selectors: {
       '&:hover, &:focus': {
@@ -39,7 +39,7 @@ export const greenOutlineButtonStyle = style([
 export const greenGhostButtonStyle = style([
   baseButtonStyle,
   {
-    backgroundColor: colorVars.gold1,
+    backgroundColor: 'transparent',
     color: colorVars.green11,
     selectors: {
       '&:hover, &:focus': {
@@ -55,7 +55,7 @@ export const greenGhostButtonStyle = style([
 export const greenLinkButtonStyle = style([
   baseButtonStyle,
   {
-    backgroundColor: colorVars.gold1,
+    backgroundColor: 'transparent',
     color: colorVars.green11,
     selectors: {
       '&:hover, &:focus': {

--- a/frontend/techpick/src/styles/greenButtonStyle.css.ts
+++ b/frontend/techpick/src/styles/greenButtonStyle.css.ts
@@ -1,6 +1,6 @@
 import { style } from '@vanilla-extract/css';
 import { colorVars } from 'techpick-shared';
-import { baseButtonStyle, outlineButtonStyle } from './baseButtonStyle.css';
+import { baseButtonStyle } from './baseButtonStyle.css';
 
 /**
  * @description color만 설정했습니다. width, height, padding 등은 직접 설정하셔야합니다.
@@ -20,8 +20,8 @@ export const greenSolidButtonStyle = style([
  */
 export const greenOutlineButtonStyle = style([
   baseButtonStyle,
-  outlineButtonStyle,
   {
+    border: '1px solid',
     borderColor: colorVars.green7,
     backgroundColor: 'transparent',
     color: colorVars.green11,

--- a/frontend/techpick/src/styles/orangeButtonStyle.css.ts
+++ b/frontend/techpick/src/styles/orangeButtonStyle.css.ts
@@ -23,7 +23,7 @@ export const orangeOutlineButtonStyle = style([
   outlineButtonStyle,
   {
     borderColor: colorVars.orange7,
-    backgroundColor: colorVars.orange1,
+    backgroundColor: 'transparent',
     color: colorVars.orange11,
     selectors: {
       '&:hover, &:focus': {
@@ -39,7 +39,7 @@ export const orangeOutlineButtonStyle = style([
 export const orangeGhostButtonStyle = style([
   baseButtonStyle,
   {
-    backgroundColor: colorVars.orange1,
+    backgroundColor: 'transparent',
     color: colorVars.orange11,
     selectors: {
       '&:hover, &:focus': {
@@ -55,7 +55,7 @@ export const orangeGhostButtonStyle = style([
 export const orangeLinkButtonStyle = style([
   baseButtonStyle,
   {
-    backgroundColor: colorVars.orange1,
+    backgroundColor: 'transparent',
     color: colorVars.orange11,
     selectors: {
       '&:hover, &:focus': {

--- a/frontend/techpick/src/styles/orangeButtonStyle.css.ts
+++ b/frontend/techpick/src/styles/orangeButtonStyle.css.ts
@@ -1,0 +1,67 @@
+import { style } from '@vanilla-extract/css';
+import { colorVars } from 'techpick-shared';
+import { baseButtonStyle, outlineButtonStyle } from './baseButtonStyle.css';
+
+/**
+ * @description color만 설정했습니다. width, height, padding 등은 직접 설정하셔야합니다.
+ */
+export const orangeSolidButtonStyle = style([
+  baseButtonStyle,
+  {
+    backgroundColor: colorVars.orange9,
+    color: 'white',
+    ':hover': { backgroundColor: colorVars.orange10 },
+    ':active': { backgroundColor: colorVars.orange11 },
+  },
+]);
+
+/**
+ * @description color만 설정했습니다. width, height, padding 등은 직접 설정하셔야합니다.
+ */
+export const orangeOutlineButtonStyle = style([
+  baseButtonStyle,
+  outlineButtonStyle,
+  {
+    borderColor: colorVars.orange7,
+    backgroundColor: colorVars.orange1,
+    color: colorVars.orange11,
+    selectors: {
+      '&:hover, &:focus': {
+        backgroundColor: colorVars.orange3,
+      },
+    },
+  },
+]);
+
+/**
+ * @description color만 설정했습니다. width, height, padding 등은 직접 설정하셔야합니다.
+ */
+export const orangeGhostButtonStyle = style([
+  baseButtonStyle,
+  {
+    backgroundColor: colorVars.orange1,
+    color: colorVars.orange11,
+    selectors: {
+      '&:hover, &:focus': {
+        backgroundColor: colorVars.orange3,
+      },
+    },
+  },
+]);
+
+/**
+ * @description color만 설정했습니다. width, height, padding 등은 직접 설정하셔야합니다.
+ */
+export const orangeLinkButtonStyle = style([
+  baseButtonStyle,
+  {
+    backgroundColor: colorVars.orange1,
+    color: colorVars.orange11,
+    selectors: {
+      '&:hover, &:focus': {
+        backgroundColor: colorVars.orange3,
+        textDecoration: 'underline',
+      },
+    },
+  },
+]);

--- a/frontend/techpick/src/styles/orangeButtonStyle.css.ts
+++ b/frontend/techpick/src/styles/orangeButtonStyle.css.ts
@@ -1,6 +1,6 @@
 import { style } from '@vanilla-extract/css';
 import { colorVars } from 'techpick-shared';
-import { baseButtonStyle, outlineButtonStyle } from './baseButtonStyle.css';
+import { baseButtonStyle } from './baseButtonStyle.css';
 
 /**
  * @description color만 설정했습니다. width, height, padding 등은 직접 설정하셔야합니다.
@@ -20,8 +20,8 @@ export const orangeSolidButtonStyle = style([
  */
 export const orangeOutlineButtonStyle = style([
   baseButtonStyle,
-  outlineButtonStyle,
   {
+    border: '1px solid',
     borderColor: colorVars.orange7,
     backgroundColor: 'transparent',
     color: colorVars.orange11,

--- a/frontend/techpick/src/styles/redButtonStyle.css.ts
+++ b/frontend/techpick/src/styles/redButtonStyle.css.ts
@@ -1,0 +1,67 @@
+import { style } from '@vanilla-extract/css';
+import { colorVars } from 'techpick-shared';
+import { baseButtonStyle, outlineButtonStyle } from './baseButtonStyle.css';
+
+/**
+ * @description color만 설정했습니다. width, height, padding 등은 직접 설정하셔야합니다.
+ */
+export const redSolidButtonStyle = style([
+  baseButtonStyle,
+  {
+    backgroundColor: colorVars.red9,
+    color: 'white',
+    ':hover': { backgroundColor: colorVars.red10 },
+    ':active': { backgroundColor: colorVars.red11 },
+  },
+]);
+
+/**
+ * @description color만 설정했습니다. width, height, padding 등은 직접 설정하셔야합니다.
+ */
+export const redOutlineButtonStyle = style([
+  baseButtonStyle,
+  outlineButtonStyle,
+  {
+    borderColor: colorVars.red7,
+    backgroundColor: 'transparent',
+    color: colorVars.red11,
+    selectors: {
+      '&:hover, &:focus': {
+        backgroundColor: colorVars.red3,
+      },
+    },
+  },
+]);
+
+/**
+ * @description color만 설정했습니다. width, height, padding 등은 직접 설정하셔야합니다.
+ */
+export const redGhostButtonStyle = style([
+  baseButtonStyle,
+  {
+    backgroundColor: 'transparent',
+    color: colorVars.red11,
+    selectors: {
+      '&:hover, &:focus': {
+        backgroundColor: colorVars.red3,
+      },
+    },
+  },
+]);
+
+/**
+ * @description color만 설정했습니다. width, height, padding 등은 직접 설정하셔야합니다.
+ */
+export const redLinkButtonStyle = style([
+  baseButtonStyle,
+  {
+    backgroundColor: 'transparent',
+    color: colorVars.red11,
+    selectors: {
+      '&:hover, &:focus': {
+        backgroundColor: colorVars.red3,
+        textDecoration: 'underline',
+      },
+    },
+  },
+]);

--- a/frontend/techpick/src/styles/redButtonStyle.css.ts
+++ b/frontend/techpick/src/styles/redButtonStyle.css.ts
@@ -1,6 +1,6 @@
 import { style } from '@vanilla-extract/css';
 import { colorVars } from 'techpick-shared';
-import { baseButtonStyle, outlineButtonStyle } from './baseButtonStyle.css';
+import { baseButtonStyle } from './baseButtonStyle.css';
 
 /**
  * @description color만 설정했습니다. width, height, padding 등은 직접 설정하셔야합니다.
@@ -20,8 +20,8 @@ export const redSolidButtonStyle = style([
  */
 export const redOutlineButtonStyle = style([
   baseButtonStyle,
-  outlineButtonStyle,
   {
+    border: '1px solid',
     borderColor: colorVars.red7,
     backgroundColor: 'transparent',
     color: colorVars.red11,

--- a/frontend/techpick/src/styles/redButtonStyle.css.ts
+++ b/frontend/techpick/src/styles/redButtonStyle.css.ts
@@ -23,7 +23,7 @@ export const redOutlineButtonStyle = style([
   outlineButtonStyle,
   {
     borderColor: colorVars.red7,
-    backgroundColor: colorVars.red1,
+    backgroundColor: 'transparent',
     color: colorVars.red11,
     selectors: {
       '&:hover, &:focus': {
@@ -39,7 +39,7 @@ export const redOutlineButtonStyle = style([
 export const redGhostButtonStyle = style([
   baseButtonStyle,
   {
-    backgroundColor: colorVars.red1,
+    backgroundColor: 'transparent',
     color: colorVars.red11,
     selectors: {
       '&:hover, &:focus': {
@@ -55,7 +55,7 @@ export const redGhostButtonStyle = style([
 export const redLinkButtonStyle = style([
   baseButtonStyle,
   {
-    backgroundColor: colorVars.red1,
+    backgroundColor: 'transparent',
     color: colorVars.red11,
     selectors: {
       '&:hover, &:focus': {

--- a/frontend/techpick/src/styles/redButtonStyle.css.ts
+++ b/frontend/techpick/src/styles/redButtonStyle.css.ts
@@ -23,7 +23,7 @@ export const redOutlineButtonStyle = style([
   outlineButtonStyle,
   {
     borderColor: colorVars.red7,
-    backgroundColor: 'transparent',
+    backgroundColor: colorVars.red1,
     color: colorVars.red11,
     selectors: {
       '&:hover, &:focus': {
@@ -39,7 +39,7 @@ export const redOutlineButtonStyle = style([
 export const redGhostButtonStyle = style([
   baseButtonStyle,
   {
-    backgroundColor: 'transparent',
+    backgroundColor: colorVars.red1,
     color: colorVars.red11,
     selectors: {
       '&:hover, &:focus': {
@@ -55,7 +55,7 @@ export const redGhostButtonStyle = style([
 export const redLinkButtonStyle = style([
   baseButtonStyle,
   {
-    backgroundColor: 'transparent',
+    backgroundColor: colorVars.red1,
     color: colorVars.red11,
     selectors: {
       '&:hover, &:focus': {

--- a/frontend/techpick/src/styles/sandButtonStyle.css.ts
+++ b/frontend/techpick/src/styles/sandButtonStyle.css.ts
@@ -1,0 +1,67 @@
+import { style } from '@vanilla-extract/css';
+import { colorVars } from 'techpick-shared';
+import { baseButtonStyle, outlineButtonStyle } from './baseButtonStyle.css';
+
+/**
+ * @description color만 설정했습니다. width, height, padding 등은 직접 설정하셔야합니다.
+ */
+export const sandSolidButtonStyle = style([
+  baseButtonStyle,
+  {
+    backgroundColor: colorVars.sand9,
+    color: 'white',
+    ':hover': { backgroundColor: colorVars.sand10 },
+    ':active': { backgroundColor: colorVars.sand11 },
+  },
+]);
+
+/**
+ * @description color만 설정했습니다. width, height, padding 등은 직접 설정하셔야합니다.
+ */
+export const sandOutlineButtonStyle = style([
+  baseButtonStyle,
+  outlineButtonStyle,
+  {
+    borderColor: colorVars.sand7,
+    backgroundColor: 'transparent',
+    color: colorVars.sand11,
+    selectors: {
+      '&:hover, &:focus': {
+        backgroundColor: colorVars.sand3,
+      },
+    },
+  },
+]);
+
+/**
+ * @description color만 설정했습니다. width, height, padding 등은 직접 설정하셔야합니다.
+ */
+export const sandGhostButtonStyle = style([
+  baseButtonStyle,
+  {
+    backgroundColor: 'transparent',
+    color: colorVars.sand11,
+    selectors: {
+      '&:hover, &:focus': {
+        backgroundColor: colorVars.sand3,
+      },
+    },
+  },
+]);
+
+/**
+ * @description color만 설정했습니다. width, height, padding 등은 직접 설정하셔야합니다.
+ */
+export const sandLinkButtonStyle = style([
+  baseButtonStyle,
+  {
+    backgroundColor: 'transparent',
+    color: colorVars.sand11,
+    selectors: {
+      '&:hover, &:focus': {
+        backgroundColor: colorVars.sand3,
+        textDecoration: 'underline',
+      },
+    },
+  },
+]);

--- a/frontend/techpick/src/styles/sandButtonStyle.css.ts
+++ b/frontend/techpick/src/styles/sandButtonStyle.css.ts
@@ -1,6 +1,6 @@
 import { style } from '@vanilla-extract/css';
 import { colorVars } from 'techpick-shared';
-import { baseButtonStyle, outlineButtonStyle } from './baseButtonStyle.css';
+import { baseButtonStyle } from './baseButtonStyle.css';
 
 /**
  * @description color만 설정했습니다. width, height, padding 등은 직접 설정하셔야합니다.
@@ -20,8 +20,8 @@ export const sandSolidButtonStyle = style([
  */
 export const sandOutlineButtonStyle = style([
   baseButtonStyle,
-  outlineButtonStyle,
   {
+    border: '1px solid',
     borderColor: colorVars.sand7,
     backgroundColor: 'transparent',
     color: colorVars.sand11,

--- a/frontend/techpick/src/styles/sandButtonStyle.css.ts
+++ b/frontend/techpick/src/styles/sandButtonStyle.css.ts
@@ -23,7 +23,7 @@ export const sandOutlineButtonStyle = style([
   outlineButtonStyle,
   {
     borderColor: colorVars.sand7,
-    backgroundColor: colorVars.sand1,
+    backgroundColor: 'transparent',
     color: colorVars.sand11,
     selectors: {
       '&:hover, &:focus': {
@@ -39,7 +39,7 @@ export const sandOutlineButtonStyle = style([
 export const sandGhostButtonStyle = style([
   baseButtonStyle,
   {
-    backgroundColor: colorVars.sand1,
+    backgroundColor: 'transparent',
     color: colorVars.sand11,
     selectors: {
       '&:hover, &:focus': {
@@ -55,7 +55,7 @@ export const sandGhostButtonStyle = style([
 export const sandLinkButtonStyle = style([
   baseButtonStyle,
   {
-    backgroundColor: colorVars.sand1,
+    backgroundColor: 'transparent',
     color: colorVars.sand11,
     selectors: {
       '&:hover, &:focus': {

--- a/frontend/techpick/src/styles/sandButtonStyle.css.ts
+++ b/frontend/techpick/src/styles/sandButtonStyle.css.ts
@@ -23,7 +23,7 @@ export const sandOutlineButtonStyle = style([
   outlineButtonStyle,
   {
     borderColor: colorVars.sand7,
-    backgroundColor: 'transparent',
+    backgroundColor: colorVars.sand1,
     color: colorVars.sand11,
     selectors: {
       '&:hover, &:focus': {
@@ -39,7 +39,7 @@ export const sandOutlineButtonStyle = style([
 export const sandGhostButtonStyle = style([
   baseButtonStyle,
   {
-    backgroundColor: 'transparent',
+    backgroundColor: colorVars.sand1,
     color: colorVars.sand11,
     selectors: {
       '&:hover, &:focus': {
@@ -55,7 +55,7 @@ export const sandGhostButtonStyle = style([
 export const sandLinkButtonStyle = style([
   baseButtonStyle,
   {
-    backgroundColor: 'transparent',
+    backgroundColor: colorVars.sand1,
     color: colorVars.sand11,
     selectors: {
       '&:hover, &:focus': {


### PR DESCRIPTION
- Close #864 

## What is this PR? 🔍

- 기능 :
- issue : #864 

## Changes 📝
개발하며 발생하던 중복 코드를 제거했습니다.
- 버튼 스타일을 공통 스타일로 추출했습니다. 현재 사용하는 outline 스타일 외에도 solid, ghost, link의 버튼 스타일을 추가했습니다. 색만 지정해주므로 width와 height, padding등의 스타일은 직접 추가해서 사용해야합니다. (chakra ui를 참고했습니다. [참고링크](https://v2.chakra-ui.com/docs/components/button#button-variants))

- 다이얼로그 스타일을 공통 스타일로 추출했습니다. `dialogOverlayStyle`과 `dialogContentStyle`로 공통 추출했습니다. `dialogContentStyle`도 버튼과 마찬가지로 width와 height, padding등의 공간은 직접 추가해서 사용해야합니다.

- dragOverlay의 중복성도 제거했습니다. `PickRecord` 컴포넌트를 예시로 들면 `PickRecord`를 수정하면 `PickRecordOverlay`의 style도 변경해야했는데 이제 `PickRecord`을 수정하면 `PickRecordOverlay`도 동일한 적용을 받게 됩니다.

<!--
## ScreenShot 📷
이번 PR에서의 변경점

| Before                     | After                     |
| -------------------------- | ------------------------- |
| ![Before Image](링크_넣기) | ![After Image](링크_넣기) |
-->

## Precaution
- 커밋을 조금 보기 힘들게 해서 커밋별로 보는 것이 아니라 PR별로 코드를 보는 것이 좋을 것 같습니다!
<!-- ## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint` -->
