### PR TITLE
[FIX] 잘못된 이미지 url일 때 엑스박스가 표기되는 문제 해결

### DIFF
--- a/frontend/techpick/src/components/DragOverlay/DragOverlay.tsx
+++ b/frontend/techpick/src/components/DragOverlay/DragOverlay.tsx
@@ -9,9 +9,9 @@ import {
 } from '@/stores';
 import { dragCountStyle, stackedOverlayStyle } from './dragOverlay.css';
 import { FolderItemOverlay } from './FolderItemOverlay';
+import { PickCarouselCardOverlay } from './PickCarouselCardOverlay';
 import { PickDragOverlayShadowList } from './PickDragOverlayShadowList';
 import { PickRecordOverlay } from './PickRecordOverlay';
-import { PickCarouselCard } from '../RecommendedPickCarousel/PickCarouselCard';
 
 export function DargOverlay({ elementClickPosition }: DargOverlayProps) {
   const { isDragging: isFolderDragging, draggingFolderInfo } = useTreeStore();
@@ -67,7 +67,7 @@ export function DargOverlay({ elementClickPosition }: DargOverlayProps) {
   if (isRecommendPickDragging && draggingRecommendPickInfo) {
     return (
       <DragOverlayPrimitive style={recommendPickOverlayStyle}>
-        <PickCarouselCard recommendPick={draggingRecommendPickInfo} />
+        <PickCarouselCardOverlay recommendPick={draggingRecommendPickInfo} />
       </DragOverlayPrimitive>
     );
   }

--- a/frontend/techpick/src/components/DragOverlay/PickCarouselCardOverlay.tsx
+++ b/frontend/techpick/src/components/DragOverlay/PickCarouselCardOverlay.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import Image from 'next/image';
+import { postRecommendPickViewEventLog } from '@/apis/eventLog';
+import { useOpenUrlInNewTab, useImageLoader } from '@/hooks';
+import {
+  pickCarouselItemStyle,
+  pickTitleStyle,
+  pickImageStyle,
+  defaultImageStyle,
+  defaultImageLayoutStyle,
+} from '../RecommendedPickCarousel/pickCarouselCard.css';
+import { RecommendPickType } from '@/types';
+
+export function PickCarouselCardOverlay({
+  recommendPick,
+}: PickCarouselCardOverlayProps) {
+  const { openUrlInNewTab } = useOpenUrlInNewTab(recommendPick.url);
+  const { imageStatus } = useImageLoader(recommendPick.imageUrl);
+
+  const onOpenLink = async () => {
+    try {
+      openUrlInNewTab();
+      await postRecommendPickViewEventLog({ url: recommendPick.url });
+    } catch {
+      /*empty */
+    }
+  };
+
+  return (
+    <div className={pickCarouselItemStyle} onClick={onOpenLink}>
+      {imageStatus === 'loaded' ? (
+        <img
+          src={recommendPick.imageUrl}
+          alt=""
+          className={pickImageStyle}
+          width="250"
+          height="131"
+        />
+      ) : (
+        <div className={defaultImageLayoutStyle}>
+          <Image
+            src={'/image/default_image.svg'}
+            alt=""
+            className={`${defaultImageStyle}`}
+            width="80"
+            height="65"
+          />
+        </div>
+      )}
+
+      <p className={pickTitleStyle}>{recommendPick.title}</p>
+    </div>
+  );
+}
+
+interface PickCarouselCardOverlayProps {
+  recommendPick: RecommendPickType;
+}

--- a/frontend/techpick/src/components/DragOverlay/PickRecordOverlay.tsx
+++ b/frontend/techpick/src/components/DragOverlay/PickRecordOverlay.tsx
@@ -2,18 +2,20 @@
 
 import Image from 'next/image';
 import { ExternalLink as ExternalLinkIcon } from 'lucide-react';
+import { useImageLoader } from '@/hooks';
 import { useTagStore } from '@/stores';
 import { formatDateString } from '@/utils';
+import { pickRecordOverlayLayoutStyle } from './pickRecordOverlay.css';
+import { PickDateColumnLayout } from '../PickRecord/PickDateColumnLayout';
+import { PickImageColumnLayout } from '../PickRecord/PickImageColumnLayout';
 import {
-  pickRecordLayoutStyle,
   pickImageStyle,
   pickTitleSectionStyle,
   dateTextStyle,
-  externalLinkIconStyle,
   linkLayoutStyle,
-} from './pickRecordOverlay.css';
-import { PickDateColumnLayout } from '../PickRecord/PickDateColumnLayout';
-import { PickImageColumnLayout } from '../PickRecord/PickImageColumnLayout';
+  externalLinkIconStyle,
+  imageStyle,
+} from '../PickRecord/pickRecord.css';
 import { PickTagColumnLayout } from '../PickRecord/PickTagColumnLayout';
 import { PickTitleColumnLayout } from '../PickRecord/PickTitleColumnLayout';
 import { Separator } from '../PickRecord/Separator';
@@ -24,24 +26,26 @@ export function PickRecordOverlay({ pickInfo }: PickViewItemComponentProps) {
   const pick = pickInfo;
   const link = pickInfo.linkInfo;
   const { findTagById } = useTagStore();
+  const { imageStatus } = useImageLoader(link.imageUrl);
 
-  const filteredSelectedTagList: TagType[] = [];
-
-  pickInfo.tagIdOrderedList.forEach((tagId) => {
-    const tagInfo = findTagById(tagId);
-    if (tagInfo) {
-      filteredSelectedTagList.push(tagInfo);
-    }
-  });
+  const filteredSelectedTagList: TagType[] = pickInfo.tagIdOrderedList
+    .map((tagId) => findTagById(tagId))
+    .filter((tag): tag is TagType => tag !== undefined);
 
   return (
-    <div className={pickRecordLayoutStyle}>
+    <div className={pickRecordOverlayLayoutStyle}>
       <PickImageColumnLayout>
         <div className={pickImageStyle}>
-          {link.imageUrl ? (
-            <Image src={link.imageUrl} alt="" fill />
+          {imageStatus === 'loaded' ? (
+            <img
+              src={link.imageUrl}
+              alt=""
+              width="96px"
+              height="47.25px"
+              className={imageStyle}
+            />
           ) : (
-            <Image src={'/image/default_image.svg'} alt="" fill sizes="96px" />
+            <Image src="/image/default_image.svg" alt="" fill sizes="96px" />
           )}
         </div>
       </PickImageColumnLayout>

--- a/frontend/techpick/src/components/DragOverlay/pickRecordOverlay.css.ts
+++ b/frontend/techpick/src/components/DragOverlay/pickRecordOverlay.css.ts
@@ -1,65 +1,11 @@
 import { style } from '@vanilla-extract/css';
-import { colorVars, typography } from 'techpick-shared';
+import { colorVars } from 'techpick-shared';
+import { pickRecordLayoutStyle } from '../PickRecord/pickRecord.css';
 
-export const pickRecordLayoutStyle = style({
-  position: 'relative',
-  display: 'flex',
-  alignItems: 'center',
-  width: '1044px',
-  minHeight: '60px',
-  height: 'fit-content',
-  borderTop: '0.5px solid',
-  borderBottom: '0.5px solid',
-  borderColor: colorVars.gold7,
-  background: colorVars.gold3,
-  opacity: '0.8',
-});
-
-export const pickImageStyle = style({
-  position: 'relative',
-  width: '96px',
-  aspectRatio: '1280 / 630',
-  // objectFit: 'cover',
-  borderRadius: '2px',
-});
-
-export const pickTitleSectionStyle = style({
-  fontSize: typography.fontSize['sm'],
-  fontWeight: typography.fontWeights['light'],
-  minHeight: '20px',
-  maxHeight: '40px',
-  lineHeight: '20px',
-  overflow: 'hidden',
-  textOverflow: 'ellipsis',
-  cursor: 'pointer',
-  wordBreak: 'break-all',
-  display: '-webkit-box',
-  WebkitLineClamp: 2,
-  WebkitBoxOrient: 'vertical',
-});
-
-export const dateTextStyle = style({
-  fontSize: typography.fontSize['sm'],
-  fontWeight: typography.fontWeights['normal'],
-  color: colorVars.gray11,
-  whiteSpace: 'nowrap',
-});
-
-export const linkLayoutStyle = style({
-  position: 'absolute',
-  width: '104px',
-  height: '60px',
-  backgroundColor: colorVars.gold12,
-  opacity: '0.7',
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  cursor: 'pointer',
-});
-
-export const externalLinkIconStyle = style({
-  width: '28px',
-  height: '28px',
-  cursor: 'pointer',
-  color: colorVars.white,
-});
+export const pickRecordOverlayLayoutStyle = style([
+  pickRecordLayoutStyle,
+  {
+    background: colorVars.gold3,
+    opacity: '0.8',
+  },
+]);

--- a/frontend/techpick/src/components/PickRecord/PickRecord.tsx
+++ b/frontend/techpick/src/components/PickRecord/PickRecord.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import Image from 'next/image';
 import { ExternalLink as ExternalLinkIcon } from 'lucide-react';
 import { postUserPickViewEventLog } from '@/apis/eventLog';
-import { useOpenUrlInNewTab } from '@/hooks';
+import { useImageLoader, useOpenUrlInNewTab } from '@/hooks';
 import { usePickStore, useTagStore, useUpdatePickStore } from '@/stores';
 import { formatDateString } from '@/utils';
 import { PickDateColumnLayout } from './PickDateColumnLayout';
@@ -39,6 +39,7 @@ export function PickRecord({ pickInfo }: PickViewItemComponentProps) {
   const [isHovered, setIsHovered] = useState(false);
   const isUpdateTitle = currentUpdateTitlePickId === pickInfo.id;
   const { isDragging } = usePickStore();
+  const { imageStatus } = useImageLoader(link.imageUrl);
 
   const filteredSelectedTagList: TagType[] = [];
 
@@ -66,7 +67,9 @@ export function PickRecord({ pickInfo }: PickViewItemComponentProps) {
     >
       <PickImageColumnLayout>
         <div className={pickImageStyle}>
-          {link.imageUrl && link.imageUrl !== '' ? (
+          {imageStatus === 'error' ? (
+            <Image src={'/image/default_image.svg'} alt="" fill sizes="96px" />
+          ) : (
             <img
               src={link.imageUrl}
               alt=""
@@ -74,8 +77,6 @@ export function PickRecord({ pickInfo }: PickViewItemComponentProps) {
               height="47.25px"
               className={imageStyle}
             />
-          ) : (
-            <Image src={'/image/default_image.svg'} alt="" fill sizes="96px" />
           )}
         </div>
       </PickImageColumnLayout>

--- a/frontend/techpick/src/components/PickRecord/SharePickRecord.tsx
+++ b/frontend/techpick/src/components/PickRecord/SharePickRecord.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import Image from 'next/image';
 import { ExternalLink as ExternalLinkIcon } from 'lucide-react';
 import { postSharedPickViewEventLog } from '@/apis/eventLog';
-import { useOpenUrlInNewTab } from '@/hooks';
+import { useImageLoader, useOpenUrlInNewTab } from '@/hooks';
 import { formatDateString } from '@/utils';
 import { PickDateColumnLayout } from './PickDateColumnLayout';
 import { PickImageColumnLayout } from './PickImageColumnLayout';
@@ -38,6 +38,7 @@ export function SharePickRecord({
   const link = pickInfo.linkInfo!;
   const { openUrlInNewTab } = useOpenUrlInNewTab(link.url);
   const [isHovered, setIsHovered] = useState(false);
+  const { imageStatus } = useImageLoader(link.imageUrl);
 
   const onClickLink = async () => {
     try {
@@ -60,7 +61,9 @@ export function SharePickRecord({
     >
       <PickImageColumnLayout>
         <div className={pickImageStyle}>
-          {link.imageUrl && link.imageUrl !== '' ? (
+          {imageStatus === 'error' ? (
+            <Image src={'/image/default_image.svg'} alt="" fill sizes="96px" />
+          ) : (
             <img
               src={link.imageUrl}
               alt=""
@@ -68,8 +71,6 @@ export function SharePickRecord({
               height="47.25px"
               className={imageStyle}
             />
-          ) : (
-            <Image src={'/image/default_image.svg'} alt="" fill sizes="96px" />
           )}
         </div>
       </PickImageColumnLayout>

--- a/frontend/techpick/src/components/RecommendedPickCarousel/PickCarouselCard.tsx
+++ b/frontend/techpick/src/components/RecommendedPickCarousel/PickCarouselCard.tsx
@@ -2,7 +2,7 @@
 
 import Image from 'next/image';
 import { postRecommendPickViewEventLog } from '@/apis/eventLog';
-import { useOpenUrlInNewTab } from '@/hooks';
+import { useOpenUrlInNewTab, useImageLoader } from '@/hooks';
 import {
   pickCarouselItemStyle,
   pickTitleStyle,
@@ -14,6 +14,7 @@ import { RecommendPickType } from '@/types';
 
 export function PickCarouselCard({ recommendPick }: PickCarouselCardProps) {
   const { openUrlInNewTab } = useOpenUrlInNewTab(recommendPick.url);
+  const { imageStatus } = useImageLoader(recommendPick.imageUrl);
 
   const onOpenLink = async () => {
     try {
@@ -26,7 +27,19 @@ export function PickCarouselCard({ recommendPick }: PickCarouselCardProps) {
 
   return (
     <div className={pickCarouselItemStyle} onClick={onOpenLink}>
-      {recommendPick.imageUrl === '' ? (
+      {imageStatus === 'loading' && (
+        <div className={defaultImageLayoutStyle}></div>
+      )}
+      {imageStatus === 'loaded' && (
+        <img
+          src={recommendPick.imageUrl}
+          alt=""
+          className={pickImageStyle}
+          width="250"
+          height="131"
+        />
+      )}
+      {imageStatus === 'error' && (
         <div className={defaultImageLayoutStyle}>
           <Image
             src={'/image/default_image.svg'}
@@ -36,16 +49,7 @@ export function PickCarouselCard({ recommendPick }: PickCarouselCardProps) {
             height="65"
           />
         </div>
-      ) : (
-        <img
-          src={recommendPick.imageUrl}
-          alt=""
-          className={pickImageStyle}
-          width="250"
-          height="131"
-        />
       )}
-
       <p className={pickTitleStyle}>{recommendPick.title}</p>
     </div>
   );

--- a/frontend/techpick/src/hooks/index.ts
+++ b/frontend/techpick/src/hooks/index.ts
@@ -12,3 +12,4 @@ export { useFetchPickRecordByFolderId } from './useFetchPickRecordByFolderId';
 export { useDisclosure } from './useDisclosure';
 export { useRecommendPickToFolderDndMonitor } from './useRecommendPickToFolderDndMonitor';
 export { useLocalStorage } from './useLocalStorage';
+export { useImageLoader } from './useImageLoader';

--- a/frontend/techpick/src/hooks/useImageLoader.ts
+++ b/frontend/techpick/src/hooks/useImageLoader.ts
@@ -1,0 +1,33 @@
+import { useState, useLayoutEffect } from 'react';
+
+type ImageStatus = 'loading' | 'loaded' | 'error';
+
+/**
+ *
+ * @param imageUrl
+ * @description imageUrl의 상태를 나타냅니다. 'loading' | 'loaded' | 'error'
+ * @returns imageStatus
+ */
+
+export function useImageLoader(imageUrl: string | undefined) {
+  const [imageStatus, setImageStatus] = useState<ImageStatus>('loading');
+
+  useLayoutEffect(() => {
+    if (!imageUrl) {
+      setImageStatus('error');
+      return;
+    }
+
+    const img = new window.Image();
+    img.onload = () => setImageStatus('loaded');
+    img.onerror = () => setImageStatus('error');
+    img.src = imageUrl;
+
+    return () => {
+      img.onload = null;
+      img.onerror = null;
+    };
+  }, [imageUrl]);
+
+  return { imageStatus };
+}


### PR DESCRIPTION
- Close #873 

## What is this PR? 🔍
기능
- 이미지가 엑스박스가 뜨던 이유는 존재하지 않는 자원을 찾는 url 혹은 잘못된 url이 존재하기 때문이었습니다. 따라서 해당 url을 불러오는데 실패하고 엑박이 떴었습니다. 따라서 이미지가 error일 때는 default image를 보여줘야 했습니다.

잘못된 url로 이미지를 불려오려다 실패하는 네트워크 통신 예시
![K-022](https://github.com/user-attachments/assets/5b79d05b-ff7d-4101-b70d-7b305b266d06)

- issue : #873 

## Changes 📝
- `useImageLoader`라는 훅으로 해당 이미지의 상태가 loading 중인지 loaded 됐는지, 에러인지 확인하고 렌더링을 하게 변경했습니다. 
## ScreenShot 📷
이번 PR에서의 변경점

| Before                     | After                     |
| -------------------------- | ------------------------- |
| ![K-018](https://github.com/user-attachments/assets/25d88e76-997b-4ee4-b2bf-e6c5ed7f9348) | ![K-019](https://github.com/user-attachments/assets/b8d94095-f21e-46dc-88c4-8c14823e716b)|


| Before                     | After                     |
| -------------------------- | ------------------------- |
| ![K-020](https://github.com/user-attachments/assets/f34b2761-d7b5-455d-a398-ab4155517504) | ![K-021](https://github.com/user-attachments/assets/1ba75c18-3ab7-4ecb-9c06-2115d5415fdc) |

<!--
## ScreenShot 📷
이번 PR에서의 변경점

| Before                     | After                     |
| -------------------------- | ------------------------- |
| ![Before Image](링크_넣기) | ![After Image](링크_넣기) |
-->

## Precaution

<!-- ## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint` -->
