### PR TITLE
[REFACTOR] og:image 파싱 로직 수정

### DIFF
--- a/backend/baguni-api/src/main/java/baguni/api/domain/link/service/LinkService.java
+++ b/backend/baguni-api/src/main/java/baguni/api/domain/link/service/LinkService.java
@@ -68,10 +68,7 @@ public class LinkService {
 	 * og:image 가 완전한 url 형식이 아닐 수 있어 보정
 	 * 추론 불가능한 image url 일 경우 빈스트링("")으로 대치
 	 *
-	 * @author sangwon
-	 * */
-
-	/**
+	 * 	@author sangwon
 	 * 	protocol : https
 	 * 	host : blog.dongolab.com
 	 */

--- a/backend/baguni-api/src/main/java/baguni/api/domain/link/service/LinkService.java
+++ b/backend/baguni-api/src/main/java/baguni/api/domain/link/service/LinkService.java
@@ -1,5 +1,8 @@
 package baguni.api.domain.link.service;
 
+import java.net.MalformedURLException;
+import java.net.URL;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -64,20 +67,45 @@ public class LinkService {
 	/**
 	 * og:image 가 완전한 url 형식이 아닐 수 있어 보정
 	 * 추론 불가능한 image url 일 경우 빈스트링("")으로 대치
+	 *
+	 * @author sangwon
 	 * */
+
+	/**
+	 * 	protocol : https
+	 * 	host : blog.dongolab.com
+	 */
 	private String correctImageUrl(String baseUrl, String imageUrl) {
+		if (imageUrl == null || imageUrl.trim().isEmpty()) {
+			return "";
+		}
+
 		if (imageUrl.startsWith("://")) {
 			return "https" + imageUrl;
 		}
 		if (imageUrl.startsWith("//")) {
 			return "https:" + imageUrl;
 		}
-		if (imageUrl.startsWith("/")) {
-			return baseUrl + imageUrl;
-		}
-		if (!imageUrl.startsWith("https://")) {
+
+		try {
+			URL url = new URL(baseUrl);
+			// ex) https://blog.dongolab.com
+			String domain = url.getProtocol() + "://" + url.getHost();
+
+			// ex) /og-image.png -> https://blog.dongholab.com/og-image.png
+			if (imageUrl.startsWith("/")) {
+				return domain + imageUrl;
+			}
+
+			if (!imageUrl.startsWith("http://") && !imageUrl.startsWith("https://")) {
+				return domain + "/" + imageUrl;
+			}
+
+			return imageUrl;
+		} catch (MalformedURLException e) {
+			// baseUrl이 올바르지 않은 경우 빈 문자열 반환
 			return "";
 		}
-		return imageUrl;
 	}
+
 }


### PR DESCRIPTION
- Close #874

## What is this PR? 🔍

- 기능 : og:image 파싱 로직 수정
- issue : #874

## Changes 📝
- 자바 URL 객체 이용하여 host 뒤에 있는 path name(세부 url) 정보들은 사용하지 않도록 하였습니다.
- 예를 들어, https://blog.dongholab.com/about 경로가 있다면,
  - https://blog.dongholab.com 정보만 활용하도록 하였습니다.
- 이미지 url이 상대 경로인 경우
  - base_url :  https://blog.dongholab.com
  - image_url : /og-image.png
  - base_url + image_url
  - 결과 값 : https://blog.dongholab.com/og-image.png