### PR TITLE
[REFACTOR] property 속성에 og 데이터가 없는 경우 name 속성 활용하도록 변경

### DIFF
--- a/backend/baguni-api/src/main/java/baguni/api/domain/link/service/LinkService.java
+++ b/backend/baguni-api/src/main/java/baguni/api/domain/link/service/LinkService.java
@@ -54,12 +54,21 @@ public class LinkService {
 		}
 	}
 
+	/**
+	 *	property 속성에 og 데이터가 없는 경우, name 속성에 있는 데이터 활용
+	 */
 	private Link updateOpengraph(String url, Link link) throws OpenGraphException {
 		var openGraph = new OpenGraph(url);
 		link.updateMetadata(
-			openGraph.getTag(Metadata.TITLE).orElse(""),
-			openGraph.getTag(Metadata.DESCRIPTION).orElse(""),
-			correctImageUrl(url, openGraph.getTag(Metadata.IMAGE).orElse(""))
+			openGraph.getTag(Metadata.OG_TITLE)
+				.orElse(openGraph.getTag(Metadata.TITLE)
+					.orElse("")),
+			openGraph.getTag(Metadata.OG_DESCRIPTION)
+				.orElse(openGraph.getTag(Metadata.DESCRIPTION)
+					.orElse("")),
+			correctImageUrl(url, openGraph.getTag(Metadata.OG_IMAGE)
+				.orElse(openGraph.getTag(Metadata.IMAGE)
+					.orElse("")))
 		);
 		return link;
 	}

--- a/backend/baguni-core/src/main/java/baguni/core/lib/opengraph/Metadata.java
+++ b/backend/baguni-core/src/main/java/baguni/core/lib/opengraph/Metadata.java
@@ -12,14 +12,18 @@ public class Metadata {
 	 ***************************************/
 
 	// The title of your object as it should appear within the graph, e.g., "The Rock".
-	public static final MetadataTag TITLE = MetadataTag.of("og:title");
+	public static final MetadataTag TITLE = MetadataTag.of("title");
+
+	public static final MetadataTag OG_TITLE = MetadataTag.of("og:title");
 
 	//  The type of your object, e.g., "video.movie".
 	//  Depending on the type you specify, other properties may also be required.
 	public static final MetadataTag TYPE = MetadataTag.of("og:type");
 
 	// An image URL which should represent your object within the graph.
-	public static final MetadataTag IMAGE = MetadataTag.of("og:image");
+	public static final MetadataTag IMAGE = MetadataTag.of("image");
+
+	public static final MetadataTag OG_IMAGE = MetadataTag.of("og:image");
 
 	// The canonical URL of your object that will be used as its permanent ID in the graph, e.g., "https://www.imdb.com/title/tt0117500/".
 	public static final MetadataTag URL = MetadataTag.of("og:url");
@@ -32,7 +36,9 @@ public class Metadata {
 	public static final MetadataTag AUDIO = MetadataTag.of("og:audio");
 
 	// A one to two sentence description of your object.
-	public static final MetadataTag DESCRIPTION = MetadataTag.of("og:description");
+	public static final MetadataTag DESCRIPTION = MetadataTag.of("description");
+
+	public static final MetadataTag OG_DESCRIPTION = MetadataTag.of("og:description");
 
 	//  The word that appears before this object's title in a sentence. An enum of (a, an, the, "", auto). If auto is
 	//  chosen, the consumer of your data should chose between "a" or "an". Default is "" (blank).


### PR DESCRIPTION
- Close #878

## What is this PR? 🔍

- 기능 : property 속성에 og 데이터가 없는 경우 name 속성 활용하도록 변경
- issue : #878

## Changes 📝
- property 속성에 og:image가 없는데 name 속성에 image가 있는 경우가 있습니다.
- 이러한 경우를 위해 property 속성에 og 데이터가 없는 경우 name 속성을 활용하도록 변경하였습니다.
- Jsoup의 `children()` 메서드가 아닌 `select()` 메서드를 사용하는 것으로 변경하였습니다.