### PR TITLE
[FEAT] 미분류로 즉시 북마크 담는 API 구현

### DIFF
--- a/backend/baguni-api/src/main/java/baguni/api/application/pick/controller/PickApiController.java
+++ b/backend/baguni-api/src/main/java/baguni/api/application/pick/controller/PickApiController.java
@@ -190,7 +190,7 @@ public class PickApiController {
 		@ApiResponse(responseCode = "200", description = "픽 생성 성공"),
 		@ApiResponse(responseCode = "404", description = "OG 태그 업데이트를 위한 크롤링 요청 실패")
 	})
-	public ResponseEntity<PickApiResponse.Pick> savePickFromUnclassified(@LoginUserId Long userId,
+	public ResponseEntity<PickApiResponse.Pick> savePickAsUnclassified(@LoginUserId Long userId,
 		@Valid @RequestBody PickApiRequest.Extension request) {
 		// Jsoup으로 og 데이터를 가져옵니다.
 		LinkInfo linkInfo = linkService.getOgTag(request.url(), request.title());

--- a/backend/baguni-api/src/main/java/baguni/api/application/pick/dto/PickApiMapper.java
+++ b/backend/baguni-api/src/main/java/baguni/api/application/pick/dto/PickApiMapper.java
@@ -10,6 +10,7 @@ import org.mapstruct.ReportingPolicy;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 
+import baguni.api.domain.link.dto.LinkInfo;
 import baguni.api.domain.pick.dto.PickCommand;
 import baguni.api.domain.pick.dto.PickResult;
 
@@ -24,12 +25,13 @@ public interface PickApiMapper {
 
 	PickCommand.ReadList toReadListCommand(Long userId, List<Long> folderIdList);
 
-	PickCommand.Search toSearchCommand(Long userId, PickApiRequest.Search request);
-
 	PickCommand.SearchPagination toSearchPaginationCommand(Long userId, List<Long> folderIdList,
 		List<String> searchTokenList, List<Long> tagIdList, Long cursor, Integer size);
 
 	PickCommand.Create toCreateCommand(Long userId, PickApiRequest.Create request);
+
+	@Mapping(source = "linkInfo", target = "linkInfo")
+	PickCommand.Extension toExtensionCommand(Long userId, String title, LinkInfo linkInfo);
 
 	PickCommand.Update toUpdateCommand(Long userId, PickApiRequest.Update request);
 

--- a/backend/baguni-api/src/main/java/baguni/api/application/pick/dto/PickApiRequest.java
+++ b/backend/baguni-api/src/main/java/baguni/api/application/pick/dto/PickApiRequest.java
@@ -16,28 +16,15 @@ public class PickApiRequest {
 	) {
 	}
 
+	public record Extension(
+		@Schema(example = "https://d2.naver.com/helloworld/8149881") String url,
+		@Schema(example = "GitHub Actions를 이용한 코드 리뷰 문화 개선기") String title
+	) {
+	}
+
 	public record Read(
 		@Schema(example = "1") @NotNull(message = "{id.notNull}") Long id
 	) {
-	}
-
-	public record Search(
-		@Schema(description = "조회할 폴더 ID 목록", example = "3, 4, 5") List<Long> folderIdList,
-		@Schema(description = "검색 토큰 목록", example = "Record, 스프링") List<String> searchTokenList,
-		@Schema(description = "검색 태그 ID 목록", example = "1, 2, 3") List<Long> tagIdList
-	) {
-	}
-
-	public record SearchPagination(
-		@Schema(description = "조회할 폴더 ID 목록", example = "3, 4, 5") List<Long> folderIdList,
-		@Schema(description = "검색 토큰 목록", example = "Record, 스프링") List<String> searchTokenList,
-		@Schema(description = "검색 태그 ID 목록", example = "1, 2, 3") List<Long> tagIdList,
-		@Schema(description = "픽 시작 id 조회", example = "0", defaultValue = "0") Long cursor,
-		@Schema(description = "한 페이지에 가져올 픽 개수", example = "20", defaultValue = "20") Integer size
-	) {
-		public Integer size() {
-			return size == null || size <= 0 ? 20 : size;
-		}
 	}
 
 	public record Update(

--- a/backend/baguni-api/src/main/java/baguni/api/domain/link/service/LinkService.java
+++ b/backend/baguni-api/src/main/java/baguni/api/domain/link/service/LinkService.java
@@ -32,6 +32,18 @@ public class LinkService {
 	}
 
 	@Transactional
+	public LinkInfo getOgTag(String url, String title) {
+		Link link = linkDataHandler.getOptionalLink(url).orElseGet(() -> Link.createLinkByUrl(url));
+		try {
+			Link updatedLink = updateOpengraph(url, link);
+			updatedLink.updateTitle(title);
+			return linkMapper.of(updatedLink);
+		} catch (Exception e) {
+			throw ApiLinkException.LINK_OG_TAG_UPDATE_FAILURE();
+		}
+	}
+
+	@Transactional
 	public void updateOgTag(String url) {
 		Link link = linkDataHandler.getOptionalLink(url).orElseGet(() -> Link.createLinkByUrl(url));
 		try {

--- a/backend/baguni-api/src/main/java/baguni/api/domain/pick/dto/PickCommand.java
+++ b/backend/baguni-api/src/main/java/baguni/api/domain/pick/dto/PickCommand.java
@@ -12,16 +12,15 @@ public class PickCommand {
 	public record ReadList(Long userId, List<Long> folderIdList) {
 	}
 
-	public record Search(Long userId, List<Long> folderIdList, List<String> searchTokenList,
-						 List<Long> tagIdList) {
-	}
-
 	public record SearchPagination(Long userId, List<Long> folderIdList, List<String> searchTokenList,
 								   List<Long> tagIdList, Long cursor, int size) {
 	}
 
 	public record Create(Long userId, String title, List<Long> tagIdOrderedList, Long parentFolderId,
 						 LinkInfo linkInfo) {
+	}
+
+	public record Extension(Long userId, String title, LinkInfo linkInfo) {
 	}
 
 	public record Update(Long userId, Long id, String title, Long parentFolderId, List<Long> tagIdOrderedList) {

--- a/backend/baguni-api/src/main/java/baguni/api/domain/pick/dto/PickMapper.java
+++ b/backend/baguni-api/src/main/java/baguni/api/domain/pick/dto/PickMapper.java
@@ -32,8 +32,12 @@ public interface PickMapper {
 	PickResult.FolderPickWithViewCountList toPickResultList(Long folderId, List<PickResult.PickWithViewCount> pick);
 
 	@Mapping(source = "command.title", target = "title")
+	@Mapping(source = "command.tagIdOrderedList", target = "tagIdOrderedList")
 	@Mapping(source = "parentFolder", target = "parentFolder")
 	@Mapping(source = "user", target = "user")
-	@Mapping(source = "command.tagIdOrderedList", target = "tagIdOrderedList")
 	Pick toEntity(PickCommand.Create command, User user, Folder parentFolder, Link link);
+
+	@Mapping(source = "parentFolder", target = "parentFolder")
+	@Mapping(source = "link", target = "link")
+	Pick toEntityByExtension(String title, List<Long> tagIdOrderedList, User user, Folder parentFolder, Link link);
 }

--- a/backend/baguni-api/src/main/java/baguni/api/domain/pick/service/PickSearchService.java
+++ b/backend/baguni-api/src/main/java/baguni/api/domain/pick/service/PickSearchService.java
@@ -62,27 +62,6 @@ public class PickSearchService {
 		);
 	}
 
-	@Transactional(readOnly = true)
-	public List<PickResult.Pick> searchPick(PickCommand.Search command) {
-		List<Long> folderIdList = command.folderIdList();
-		List<Long> tagIdList = command.tagIdList();
-
-		if (ObjectUtils.isNotEmpty(folderIdList)) {
-			for (Long folderId : folderIdList) {
-				validateFolderAccess(command.userId(), folderId);
-				validateFolderRootSearch(folderId);
-			}
-		}
-
-		if (ObjectUtils.isNotEmpty(tagIdList)) {
-			for (Long tagId : tagIdList) {
-				validateTagAccess(command.userId(), tagId);
-			}
-		}
-
-		return pickQuery.searchPick(command.userId(), folderIdList, command.searchTokenList(), command.tagIdList());
-	}
-
 	private void validateFolderAccess(Long userId, Long folderId) {
 		Folder parentFolder = folderDataHandler.getFolder(folderId); // 존재하지 않으면, FOLDER_NOT_FOUND
 		if (ObjectUtils.notEqual(userId, parentFolder.getUser().getId())) {

--- a/backend/baguni-api/src/main/java/baguni/api/domain/pick/service/PickService.java
+++ b/backend/baguni-api/src/main/java/baguni/api/domain/pick/service/PickService.java
@@ -103,6 +103,12 @@ public class PickService {
 
 	@LoginUserIdDistributedLock
 	@Transactional
+	public PickResult.Pick saveExtensionPick(PickCommand.Extension command) {
+		return pickMapper.toPickResult(pickDataHandler.saveExtensionPick(command));
+	}
+
+	@LoginUserIdDistributedLock
+	@Transactional
 	public PickResult.Pick updatePick(PickCommand.Update command) {
 		validatePickAccess(command.userId(), command.id());
 		validateFolderAccess(command.userId(), command.parentFolderId());

--- a/backend/baguni-api/src/main/java/baguni/api/infrastructure/pick/PickQuery.java
+++ b/backend/baguni-api/src/main/java/baguni/api/infrastructure/pick/PickQuery.java
@@ -68,23 +68,6 @@ public class PickQuery {
 			.fetch();
 	}
 
-	public List<PickResult.Pick> searchPick(Long userId, List<Long> folderIdList, List<String> searchTokenList,
-		List<Long> tagIdList) {
-
-		return jpaQueryFactory
-			.select(pickResultFields()) // dto로 반환
-			.from(pick)
-			.leftJoin(pickTag).on(pick.id.eq(pickTag.pick.id))
-			.where(
-				userEqCondition(userId), // 본인 pick 조회
-				folderIdCondition(folderIdList), // 폴더에 해당 하는 pick 조회
-				searchTokenListCondition(searchTokenList), // 제목 검색 조건
-				tagIdListCondition(tagIdList) // 태그 검색 조건
-			)
-			.distinct()
-			.fetch();
-	}
-
 	// TODO: 본인 픽이 아닌 다른 사람의 픽도 검색하고 싶다면 userId 부분 제거
 	public Slice<PickResult.Pick> searchPickPagination(
 		Long userId, List<Long> folderIdList, List<String> searchTokenList,

--- a/backend/baguni-core/src/main/java/baguni/core/model/link/Link.java
+++ b/backend/baguni-core/src/main/java/baguni/core/model/link/Link.java
@@ -67,6 +67,13 @@ public class Link {
 		return this;
 	}
 
+	public Link updateTitle(String title) {
+		if (!StringUtils.isBlank(title)) {
+			this.title = title;
+		}
+		return this;
+	}
+
 	public Link markAsInvalid() {
 		this.invalidatedAt = LocalDateTime.now();
 		return this;

--- a/backend/baguni-core/src/main/java/baguni/core/model/pick/Pick.java
+++ b/backend/baguni-core/src/main/java/baguni/core/model/pick/Pick.java
@@ -24,15 +24,6 @@ import baguni.core.model.link.Link;
 import baguni.core.model.user.User;
 import baguni.core.util.OrderConverter;
 
-@Table(
-	name = "pick",
-	uniqueConstraints = {
-		@UniqueConstraint(
-			name = "UC_ONE_LICK_PER_USER",
-			columnNames = {"user_id", "link_id"}
-		)
-	}
-)
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)


### PR DESCRIPTION
- Close #870

## What is this PR? 🔍

- 기능 : 미분류로 즉시 북마크 담는 API
- issue : #870

## Changes 📝
- 사용하지 않는 검색 API 제거
- 픽 중복 허용 (unique index 제거)
- 미분류로 즉시 담도록 구현

## 기타 사항
### 현재 동작 방식
1. 클라이언트(익스텐션)에서 `픽 생성 요청`을 보냄
2. Jsoup을 이용하여 `OG 데이터`를 가져온다.
3. OG 데이터와 픽 생성 요청을 활용하여 Pick, Link를 `DB에 저장`한다.

이 방식을 사용했을 때의 문제점은 `API 응답이 1초 이상` 걸린다는 것입니다.
<img width="1016" alt="image" src="https://github.com/user-attachments/assets/ffd5b6b5-f71e-4d1c-a432-06451d6ef87e" />

다음 PR에서 API 응답 시간을 줄이기 위해 OG 데이터는 비동기로 처리할 예정입니다.

### 계획하는 방식
1. 클라이언트(익스텐션)에서 `픽 생성 요청`을 보냄
2. Pick, Link를 즉시 `DB에 저장`한다.
3. `메세지 큐`로 OG 데이터를 가져오라는 `메세지를 발행`한다.
4. 클라이언트에 `픽이 생성되었다는 응답`을 보내준다.
5. 메세지 큐에서 메세지를 꺼낸 후 Jsoup을 이용하여 `비동기적으로 OG 데이터를 가져온다.`
