### PR TITLE
[FEAT] 북마크 이동 시 토스트 알람 생성

### DIFF
--- a/frontend/techpick/src/hooks/usePickToFolderDndMonitor.tsx
+++ b/frontend/techpick/src/hooks/usePickToFolderDndMonitor.tsx
@@ -3,7 +3,11 @@
 import { useDndMonitor } from '@dnd-kit/core';
 import { usePickStore, useTreeStore } from '@/stores';
 import { useSearchPickStore } from '@/stores/searchPickStore';
-import { isPickDraggableObject, isPickToFolderDroppableObject } from '@/utils';
+import {
+  isPickDraggableObject,
+  isPickToFolderDroppableObject,
+  notifySuccess,
+} from '@/utils';
 import type { DragEndEvent, DragOverEvent } from '@dnd-kit/core';
 
 /**
@@ -55,6 +59,9 @@ export function usePickToFolderDndMonitor() {
     }
 
     await movePicksToDifferentFolder({ from: activeObject, to: overObject });
+    notifySuccess('다른 폴더로 북마크를 이동했습니다!', {
+      position: 'bottom-right',
+    });
     await preFetchSearchPicks();
   };
 

--- a/frontend/techpick/src/hooks/usePickToFolderDndMonitor.tsx
+++ b/frontend/techpick/src/hooks/usePickToFolderDndMonitor.tsx
@@ -59,9 +59,7 @@ export function usePickToFolderDndMonitor() {
     }
 
     await movePicksToDifferentFolder({ from: activeObject, to: overObject });
-    notifySuccess('다른 폴더로 북마크를 이동했습니다!', {
-      position: 'bottom-right',
-    });
+    notifySuccess('다른 폴더로 북마크를 이동했습니다!');
     await preFetchSearchPicks();
   };
 

--- a/frontend/techpick/src/hooks/useRecommendPickToFolderDndMonitor.tsx
+++ b/frontend/techpick/src/hooks/useRecommendPickToFolderDndMonitor.tsx
@@ -81,7 +81,9 @@ export function useRecommendPickToFolderDndMonitor() {
         linkInfo: { url, description, imageUrl, title },
       });
       insertPickInfo(createdPickInfo, overObject.id);
-      notifySuccess('성공적으로 추가되었습니다!');
+      notifySuccess('성공적으로 북마크가 추가되었습니다!', {
+        position: 'bottom-right',
+      });
     } catch {
       /** empty */
     }

--- a/frontend/techpick/src/hooks/useRecommendPickToFolderDndMonitor.tsx
+++ b/frontend/techpick/src/hooks/useRecommendPickToFolderDndMonitor.tsx
@@ -81,9 +81,7 @@ export function useRecommendPickToFolderDndMonitor() {
         linkInfo: { url, description, imageUrl, title },
       });
       insertPickInfo(createdPickInfo, overObject.id);
-      notifySuccess('성공적으로 북마크가 추가되었습니다!', {
-        position: 'bottom-right',
-      });
+      notifySuccess('성공적으로 북마크가 추가되었습니다!');
     } catch {
       /** empty */
     }


### PR DESCRIPTION
- Close #816 

## What is this PR? 🔍

- 기능 : 다른 폴더로 북마크 이동 시, 추천 페이지에서 북마크 추가 시 우측 하단에 toast 알림을 추가 했습니다. 
- issue : #816 

## Changes 📝

## ScreenShot 📷

https://github.com/user-attachments/assets/f584ca03-94e5-43d4-9b04-3a5a07f323bc


<!--
## ScreenShot 📷
이번 PR에서의 변경점

| Before                     | After                     |
| -------------------------- | ------------------------- |
| ![Before Image](링크_넣기) | ![After Image](링크_넣기) |
-->

## Precaution

<!-- ## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint` -->
