### PR TITLE
[FIX] 검색 다이얼로그 색 정상 적용

### DIFF
--- a/frontend/techpick/src/components/FolderTree/moveFolderToRecycleBinDialog.css.ts
+++ b/frontend/techpick/src/components/FolderTree/moveFolderToRecycleBinDialog.css.ts
@@ -1,11 +1,15 @@
 import { style } from '@vanilla-extract/css';
 import { colorVars } from 'techpick-shared';
-import { dialogContentStyle } from '@/styles/dialogStyle.css';
+import {
+  dialogContentLayoutStyle,
+  dialogContentBackgroundColorStyle,
+} from '@/styles/dialogStyle.css';
 import { redOutlineButtonStyle } from '@/styles/redButtonStyle.css';
 import { sandOutlineButtonStyle } from '@/styles/sandButtonStyle.css';
 
 export const moveRecycleDialogContent = style([
-  dialogContentStyle,
+  dialogContentLayoutStyle,
+  dialogContentBackgroundColorStyle,
   {
     display: 'flex',
     flexDirection: 'column',

--- a/frontend/techpick/src/components/FolderTree/shareFolderDialog.css.ts
+++ b/frontend/techpick/src/components/FolderTree/shareFolderDialog.css.ts
@@ -1,11 +1,15 @@
 import { style } from '@vanilla-extract/css';
 import { colorVars } from 'techpick-shared';
-import { dialogContentStyle } from '@/styles/dialogStyle.css';
+import {
+  dialogContentLayoutStyle,
+  dialogContentBackgroundColorStyle,
+} from '@/styles/dialogStyle.css';
 
 /* --------------- Dialog --------------- */
 
 export const dialogContent = style([
-  dialogContentStyle,
+  dialogContentLayoutStyle,
+  dialogContentBackgroundColorStyle,
   {
     display: 'flex',
     flexDirection: 'column',

--- a/frontend/techpick/src/components/PickTagPicker/DeleteTagDialog.css.ts
+++ b/frontend/techpick/src/components/PickTagPicker/DeleteTagDialog.css.ts
@@ -2,13 +2,15 @@ import { style } from '@vanilla-extract/css';
 import { zIndex } from 'techpick-shared';
 import {
   dialogOverlayStyle as baseDialogOverlayStyle,
-  dialogContentStyle as baseDialogContentStyle,
+  dialogContentLayoutStyle,
+  dialogContentBackgroundColorStyle,
 } from '@/styles/dialogStyle.css';
 import { redOutlineButtonStyle } from '@/styles/redButtonStyle.css';
 import { sandOutlineButtonStyle } from '@/styles/sandButtonStyle.css';
 
 export const dialogContentStyle = style([
-  baseDialogContentStyle,
+  dialogContentLayoutStyle,
+  dialogContentBackgroundColorStyle,
   {
     margin: 'auto',
     zIndex: zIndex.level5,

--- a/frontend/techpick/src/components/Search2/searchDialog.css.ts
+++ b/frontend/techpick/src/components/Search2/searchDialog.css.ts
@@ -1,9 +1,9 @@
 import { style } from '@vanilla-extract/css';
 import { colorVars } from 'techpick-shared';
-import { dialogContentStyle } from '@/styles/dialogStyle.css';
+import { dialogContentLayoutStyle } from '@/styles/dialogStyle.css';
 
 export const dialogContent = style([
-  dialogContentStyle,
+  dialogContentLayoutStyle,
   {
     background: 'white',
     padding: '16px',

--- a/frontend/techpick/src/components/importBookmarkDialog.css.ts
+++ b/frontend/techpick/src/components/importBookmarkDialog.css.ts
@@ -1,6 +1,9 @@
 import { style } from '@vanilla-extract/css';
 import { colorVars } from 'techpick-shared';
-import { dialogContentStyle } from '@/styles/dialogStyle.css';
+import {
+  dialogContentBackgroundColorStyle,
+  dialogContentLayoutStyle,
+} from '@/styles/dialogStyle.css';
 import { goldOutlineButtonStyle } from '@/styles/goldButtonStyle.css';
 import { greenOutlineButtonStyle } from '@/styles/greenButtonStyle.css';
 
@@ -13,7 +16,8 @@ export const importBookmarkDialogButtonStyle = style([
 ]);
 
 export const dialogContent = style([
-  dialogContentStyle,
+  dialogContentLayoutStyle,
+  dialogContentBackgroundColorStyle,
   {
     display: 'flex',
     flexDirection: 'column',

--- a/frontend/techpick/src/components/tutorialDialog.css.ts
+++ b/frontend/techpick/src/components/tutorialDialog.css.ts
@@ -1,10 +1,14 @@
 import { style } from '@vanilla-extract/css';
 import { colorVars } from 'techpick-shared';
-import { dialogContentStyle } from '@/styles/dialogStyle.css';
+import {
+  dialogContentLayoutStyle,
+  dialogContentBackgroundColorStyle,
+} from '@/styles/dialogStyle.css';
 import { orangeOutlineButtonStyle } from '@/styles/orangeButtonStyle.css';
 
 export const dialogContent = style([
-  dialogContentStyle,
+  dialogContentLayoutStyle,
+  dialogContentBackgroundColorStyle,
   {
     display: 'flex',
     flexDirection: 'column',

--- a/frontend/techpick/src/styles/dialogStyle.css.ts
+++ b/frontend/techpick/src/styles/dialogStyle.css.ts
@@ -20,9 +20,10 @@ export const dialogOverlayStyle = style({
 });
 
 /**
- * @description width, height, padding은 직접 설정해야합니다.
+ * @description width, height, padding 직접 설정해야합니다.
+ * 또한 백그라운드도 직접 설정해야합니다.
  */
-export const dialogContentStyle = style({
+export const dialogContentLayoutStyle = style({
   position: 'fixed',
   top: '50%',
   left: '50%',
@@ -32,6 +33,9 @@ export const dialogContentStyle = style({
     hsl(206 22% 7% / 35%) 0px 10px 38px -10px,
     hsl(206 22% 7% / 20%) 0px 10px 20px -15px
   `,
-  backgroundColor: colorVars.gold4,
   animation: `${contentShow} 150ms cubic-bezier(0.16, 1, 0.3, 1)`,
+});
+
+export const dialogContentBackgroundColorStyle = style({
+  backgroundColor: colorVars.gold4,
 });


### PR DESCRIPTION
- Close #ISSUE_NUMBER

## What is this PR? 🔍

- 기능 : 
@obvoso 님께서 찾아주신 기존의 검색창의 색이 이상한 것을 발견해주셨습니다.
gold4 색에서 white로 정상 적용됐습니다. 


## Changes 📝
gold4가 적용되었던 원인은 [composition](https://vanilla-extract.style/documentation/style-composition/)에서 하나의 클래스로 만드면서 나중에 적용되는 `backgroundColor`를 지운 듯 합니다. 
그래서 `dialogContentStyle`에서 `backgroundColor`를 제거했습니다.

## ScreenShot 📷
이번 PR에서의 변경점
![image](https://github.com/user-attachments/assets/03fd683b-e078-4782-84c1-514209d9973f)



<!--

| Before                     | After                     |
| -------------------------- | ------------------------- |
| ![Before Image](링크_넣기) | ![After Image](링크_넣기) |
-->

## Precaution

<!-- ## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint` -->
