### PR TITLE
[FIX] OG Image를 가져오는 경로를 절대 경로로 수정

### DIFF
--- a/.github/workflows/baguni.test.client.deploy.yml
+++ b/.github/workflows/baguni.test.client.deploy.yml
@@ -31,7 +31,7 @@ jobs:
           echo "NEXT_PUBLIC_DOMAIN=${{ secrets.FRONT_NEXT_PUBLIC_DOMAIN }}" >> .env.production
           echo "NEXT_PUBLIC_REDIRECT_URL=${{secrets.FRONT_NEXT_PUBLIC_REDIRECT_URL}}" >> .env.production
           echo "NEXT_PUBLIC_MIXPANEL_TOKEN=${{secrets.FRONT_NEXT_PUBLIC_MIXPANEL_TOKEN}}" >> .env.production
-          echo "NEXT_NEXT_PUBLIC_IMAGE_URL=${{secrets.FRONT_NEXT_PUBLIC_IMAGE_URL}}" >> .env.production
+          echo "NEXT_PUBLIC_IMAGE_URL=${{secrets.FRONT_NEXT_PUBLIC_IMAGE_URL}}" >> .env.production
 
       - # .env.sentry-build-plugin 설정
         name: Create .env.sentry-build-plugin

--- a/frontend/techpick/src/app/(unsigned)/share/[uuid]/page.tsx
+++ b/frontend/techpick/src/app/(unsigned)/share/[uuid]/page.tsx
@@ -34,6 +34,10 @@ const EmptyPickRecordImage = dynamic(
   }
 );
 
+// TODO:
+// 해당 코드는 api를 쓰는 방식이 아닌,
+// https://nextjs.org/docs/14/app/api-reference/file-conventions/metadata/opengraph-image#generate-images-using-code-js-ts-tsx
+// 에서 나오는 방식으로 변경해야합니다.
 export async function generateMetadata(
   {
     params,
@@ -54,7 +58,7 @@ export async function generateMetadata(
   let ogImageUrl: string;
 
   if (imageUrls.length === 0) {
-    ogImageUrl = `/image/og_image.png`;
+    ogImageUrl = `${process.env.NEXT_PUBLIC_IMAGE_URL}/image/og_image.png`;
   } else {
     const apiUrl = new URL(
       `${process.env.NEXT_PUBLIC_IMAGE_URL}/api/generate-og-image`

--- a/frontend/techpick/src/app/(unsigned)/share/[uuid]/page.tsx
+++ b/frontend/techpick/src/app/(unsigned)/share/[uuid]/page.tsx
@@ -54,7 +54,7 @@ export async function generateMetadata(
   let ogImageUrl: string;
 
   if (imageUrls.length === 0) {
-    ogImageUrl = `${process.env.NEXT_PUBLIC_IMAGE_URL}/image/og_image.png`;
+    ogImageUrl = `/image/og_image.png`;
   } else {
     const apiUrl = new URL(
       `${process.env.NEXT_PUBLIC_IMAGE_URL}/api/generate-og-image`

--- a/frontend/techpick/src/app/layout.tsx
+++ b/frontend/techpick/src/app/layout.tsx
@@ -13,7 +13,7 @@ export const metadata: Metadata = {
     icon: '/favicon.ico',
   },
   openGraph: {
-    images: `${process.env.NEXT_PUBLIC_IMAGE_URL}/image/og_image.png`,
+    images: `/image/og_image.png`,
   },
 };
 

--- a/frontend/techpick/src/app/layout.tsx
+++ b/frontend/techpick/src/app/layout.tsx
@@ -13,7 +13,13 @@ export const metadata: Metadata = {
     icon: '/favicon.ico',
   },
   openGraph: {
-    images: `/image/og_image.png`,
+    images: [
+      {
+        url: `${process.env.NEXT_PUBLIC_IMAGE_URL}/image/og_image.png`,
+        width: 1200,
+        height: 630,
+      },
+    ],
   },
 };
 


### PR DESCRIPTION
- Close #ISSUE_NUMBER

## What is this PR? 🔍

- 기능 :
- issue : #

## Changes 📝

현재 ogImage를 다음과 같이 가져오고 있어서 환경변수를 이용해 url을 변경했습니다.

### AS-IS
```
<meta property="og:image" content="http://localhost:3000/image/og_image.png">
```

###
```
<meta property="og:image" content="http://{환경 서버의 값}/image/og_image.png">
```

<!--
## ScreenShot 📷
이번 PR에서의 변경점

| Before                     | After                     |
| -------------------------- | ------------------------- |
| ![Before Image](링크_넣기) | ![After Image](링크_넣기) |
-->

## Precaution

<!-- ## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint` -->
