### PR TITLE
[FEAT] 픽 중복 확인하는 API 구현

### DIFF
--- a/backend/baguni-api/src/main/java/baguni/api/application/pick/controller/PickApiController.java
+++ b/backend/baguni-api/src/main/java/baguni/api/application/pick/controller/PickApiController.java
@@ -97,26 +97,20 @@ public class PickApiController {
 		return ResponseEntity.ok(new PickSliceResponse<>(pickApiMapper.toSliceApiResponse(pickResultList)));
 	}
 
-	/**
-	 * @deprecated
-	 * 현재 익스텐션에서만 사용되며, 추후 없어질 예정입니다.
-	 */
-	@Deprecated
 	@GetMapping("/link")
 	@Operation(
-		summary = "[Deprecated] 링크 픽 여부 조회",
+		summary = "링크 픽 여부 조회",
 		description = """
 				해당 링크를 픽한 적이 있는지 확인합니다.
-				픽이 존재하지 않음을 4XX로 판단하는 것이 프론트엔드에서 처리하기 까다로워
-				Deprecated 처리하였습니다.
+				boolean 값을 반환합니다.
+				true : 존재, false : 존재하지 않음.
 			""")
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "픽 여부 조회 성공"),
-		@ApiResponse(responseCode = "404", description = "해당 링크에 대해 픽이 되어 있지 않습니다.")
 	})
-	public ResponseEntity<PickApiResponse.Pick> getPickUrl(@LoginUserId Long userId,
+	public ResponseEntity<PickApiResponse.Exist> getPickUrl(@LoginUserId Long userId,
 		@RequestParam String link) {
-		return ResponseEntity.ok(pickApiMapper.toApiResponse(pickService.getPickUrl(userId, link)));
+		return ResponseEntity.ok(pickApiMapper.toApiExistResponse(pickService.existPickByUrl(userId, link)));
 	}
 
 	/**
@@ -127,7 +121,7 @@ public class PickApiController {
 	 */
 	@MeasureTime
 	@GetMapping("/link-v2")
-	@Operation(summary = "링크 픽 여부 조회", description = "해당 링크를 픽한 적이 있는지 확인합니다.")
+	@Operation(summary = "링크 픽 여부 조회 + 픽 정보 조회", description = "해당 링크를 픽한 적이 있는지 확인합니다. + 픽에 대한 정보도 반환합니다.")
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "픽 여부 조회 성공"),
 	})

--- a/backend/baguni-api/src/main/java/baguni/api/application/pick/dto/PickApiMapper.java
+++ b/backend/baguni-api/src/main/java/baguni/api/application/pick/dto/PickApiMapper.java
@@ -45,6 +45,8 @@ public interface PickApiMapper {
 
 	PickApiResponse.Pick toApiResponse(PickResult.Pick pickResult);
 
+	PickApiResponse.Exist toApiExistResponse(Boolean exist);
+
 	@Mapping(target = "pickList", source = "pickList", qualifiedByName = "mapPickList")
 	PickApiResponse.FolderPickList toApiFolderPickList(PickResult.FolderPickList folderPickList);
 

--- a/backend/baguni-api/src/main/java/baguni/api/application/pick/dto/PickApiResponse.java
+++ b/backend/baguni-api/src/main/java/baguni/api/application/pick/dto/PickApiResponse.java
@@ -53,6 +53,11 @@ public class PickApiResponse {
 	) {
 	}
 
+	public record Exist(
+		@NotNull Boolean exist
+	){
+	}
+
 	public record CreateFromRecommend(
 		boolean exist,
 		PickResult.Pick pick

--- a/backend/baguni-api/src/main/java/baguni/api/service/pick/service/PickService.java
+++ b/backend/baguni-api/src/main/java/baguni/api/service/pick/service/PickService.java
@@ -28,7 +28,6 @@ import baguni.api.infrastructure.tag.TagDataHandler;
 import baguni.common.dto.UrlWithCount;
 import baguni.entity.model.folder.Folder;
 import baguni.entity.model.folder.FolderType;
-import baguni.entity.model.link.Link;
 import baguni.entity.model.pick.Pick;
 import baguni.entity.model.tag.Tag;
 
@@ -46,8 +45,9 @@ public class PickService {
 
 	@Transactional(readOnly = true)
 	public boolean existPickByUrl(Long userId, String url) {
-		Link link = linkDataHandler.getLink(url);
-		return pickDataHandler.existsByUserIdAndLink(userId, link);
+		return linkDataHandler.getOptionalLink(url)
+			.map(link -> pickDataHandler.existsByUserIdAndLink(userId, link))
+			.orElse(false);
 	}
 
 	@Transactional(readOnly = true)


### PR DESCRIPTION
- Close #909

## What is this PR? 🔍

- 기능 : 픽 중복 확인하는 API 구현
- issue : #909

## Changes 📝
- 기존에 deprecated 되었던 `/api/picks/link`를 리팩토링 하였습니다.
- 중복된 링크가 없으면 400 에러 발생시키던 로직에서 false를 반환하도록 변경하였습니다.