### PR TITLE
[FEAT] flyway 도입

### DIFF
--- a/backend/baguni-api/src/main/resources/logback-spring.xml
+++ b/backend/baguni-api/src/main/resources/logback-spring.xml
@@ -78,6 +78,10 @@
         <appender-ref ref="CONSOLE"/>
         <appender-ref ref="APP-LOG-FILE"/>
     </logger>
+    <logger name="org.flywaydb" level="info" additivity="false">
+        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="APP-LOG-FILE"/>
+    </logger>
     <logger name="p6spy" level="info" additivity="false">
         <appender-ref ref="CONSOLE"/>
         <appender-ref ref="SQL-LOG-FILE"/>

--- a/backend/baguni-batch/src/main/resources/logback-spring.xml
+++ b/backend/baguni-batch/src/main/resources/logback-spring.xml
@@ -89,10 +89,12 @@
         <appender-ref ref="CONSOLE"/>
         <appender-ref ref="APP-LOG-FILE"/>
     </logger>
+    <logger name="org.flywaydb" level="info" additivity="false">
+        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="APP-LOG-FILE"/>
+    </logger>
     <logger name="p6spy" level="info" additivity="false">
         <appender-ref ref="CONSOLE"/>
         <appender-ref ref="SQL-LOG-FILE"/>
     </logger>
-
-
 </configuration>

--- a/backend/baguni-entity/build.gradle
+++ b/backend/baguni-entity/build.gradle
@@ -22,6 +22,10 @@ dependencies {
 
     // Sql logging formatter / https://www.baeldung.com/java-p6spy-intercept-sql-logging
     implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.2'
+
+    // flyway
+    implementation 'org.flywaydb:flyway-core'
+    implementation "org.flywaydb:flyway-mysql"
 }
 
 tasks.named('test') {

--- a/backend/baguni-entity/src/main/resources/application-entity.yaml
+++ b/backend/baguni-entity/src/main/resources/application-entity.yaml
@@ -74,7 +74,8 @@ spring:
   flyway:
     url: ${DOCKER_PROD_MYSQL_URL}
     enabled: true
+    baseline-version: 2 # V2_add_user_idToken 부터 적용 시작
 decorator:
   datasource:
-    p6spy: # 운영서버에서는 p6spy 로깅을 사용하지 않음
+    p6spy: # 운영 서버에서는 p6spy 로깅을 사용하지 않음
       enable-logging: false

--- a/backend/baguni-entity/src/main/resources/application-entity.yaml
+++ b/backend/baguni-entity/src/main/resources/application-entity.yaml
@@ -1,3 +1,6 @@
+# -----------------------------
+#       COMMON SETTINGS
+# -----------------------------
 spring:
   output:
     ansi:
@@ -14,19 +17,34 @@ spring:
         dialect: org.hibernate.dialect.MySQL8Dialect
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
+    username: ${DOCKER_MYSQL_USERNAME}
+    password: ${DOCKER_MYSQL_PASSWORD}
+  flyway:
+    user: ${DOCKER_MYSQL_USERNAME}
+    password: ${DOCKER_MYSQL_PASSWORD}
+    schemas: ${DOCKER_MYSQL_DATABASE}
+
 ---
+# -----------------------------
+#       LOCAL SETTINGS
+# -----------------------------
 spring:
   config:
     activate:
       on-profile: local
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: validate
   datasource:
     url: ${DOCKER_LOCAL_MYSQL_URL}
-    username: ${DOCKER_MYSQL_USERNAME}
-    password: ${DOCKER_MYSQL_PASSWORD}
+  flyway:
+    url: ${DOCKER_LOCAL_MYSQL_URL}
+    enabled: true
+
 ---
+# -----------------------------
+#     DEVELOPMENT SETTINGS
+# -----------------------------
 spring:
   config:
     activate:
@@ -36,9 +54,14 @@ spring:
       ddl-auto: validate
   datasource:
     url: ${DOCKER_DEV_MYSQL_URL}
-    username: ${DOCKER_MYSQL_USERNAME}
-    password: ${DOCKER_MYSQL_PASSWORD}
+  flyway:
+    url: ${DOCKER_DEV_MYSQL_URL}
+    enabled: true
+
 ---
+# -----------------------------
+#     PRODUCTION SETTINGS
+# -----------------------------
 spring:
   config:
     activate:
@@ -48,13 +71,10 @@ spring:
       ddl-auto: none
   datasource:
     url: ${DOCKER_PROD_MYSQL_URL}
-    username: ${DOCKER_MYSQL_USERNAME}
-    password: ${DOCKER_MYSQL_PASSWORD}
-# 운영서버에서는 p6spy 로깅을 사용하지 않음
-# @Profile 로 처리했었지만, logback 때문인지 제대로 적용되지 않아 yaml 에 추가
-# by psh
+  flyway:
+    url: ${DOCKER_PROD_MYSQL_URL}
+    enabled: true
 decorator:
   datasource:
-    p6spy:
+    p6spy: # 운영서버에서는 p6spy 로깅을 사용하지 않음
       enable-logging: false
----

--- a/backend/baguni-entity/src/main/resources/application-entity.yaml
+++ b/backend/baguni-entity/src/main/resources/application-entity.yaml
@@ -39,6 +39,7 @@ spring:
     url: ${DOCKER_LOCAL_MYSQL_URL}
   flyway:
     url: ${DOCKER_LOCAL_MYSQL_URL}
+    baseline-on-migrate: true
     enabled: true
 
 ---
@@ -56,6 +57,7 @@ spring:
     url: ${DOCKER_DEV_MYSQL_URL}
   flyway:
     url: ${DOCKER_DEV_MYSQL_URL}
+    baseline-on-migrate: true
     enabled: true
 
 ---
@@ -73,8 +75,8 @@ spring:
     url: ${DOCKER_PROD_MYSQL_URL}
   flyway:
     url: ${DOCKER_PROD_MYSQL_URL}
+    baseline-on-migrate: true
     enabled: true
-    baseline-version: 2 # V2_add_user_idToken 부터 적용 시작
 decorator:
   datasource:
     p6spy: # 운영 서버에서는 p6spy 로깅을 사용하지 않음

--- a/backend/baguni-entity/src/main/resources/db/migration/V1__init_schema.sql
+++ b/backend/baguni-entity/src/main/resources/db/migration/V1__init_schema.sql
@@ -1,0 +1,139 @@
+create table baguni_db.link
+(
+    id                bigint auto_increment
+        primary key,
+    invalidated_at_at datetime(6)  null,
+    description       text         null,
+    image_url         text         null,
+    title             text         null,
+    url               varchar(600) not null,
+    constraint UK4dycbe6q8trcendnql3b13cuf
+        unique (url)
+);
+
+create table baguni_db.rss_blog
+(
+    created_at datetime(6)  not null,
+    id         bigint auto_increment
+        primary key,
+    updated_at datetime(6)  not null,
+    blog_name  varchar(255) not null,
+    url        varchar(255) not null,
+    constraint UKhkgcu0q1xs43reu4pa6xhpt24
+        unique (blog_name),
+    constraint UKs6orlq8fncv7ps4wpp05o1pv
+        unique (url)
+);
+
+create table baguni_db.rss_raw_data
+(
+    created_at      datetime(6)  not null,
+    id              bigint auto_increment
+        primary key,
+    rss_blog_id     bigint       null,
+    updated_at      datetime(6)  not null,
+    creator         varchar(255) null,
+    description     longblob     null,
+    guid            varchar(255) null,
+    joined_category varchar(255) null,
+    published_at    varchar(255) null,
+    title           varchar(255) null,
+    url             varchar(600) null
+);
+
+create table baguni_db.user
+(
+    created_at         datetime(6)                                    not null,
+    id                 bigint auto_increment
+        primary key,
+    updated_at         datetime(6)                                    not null,
+    email              varchar(255)                                   not null,
+    nickname           varchar(255)                                   null,
+    password           varchar(255)                                   null,
+    social_provider_id varchar(255)                                   null,
+    tag_order          longblob                                       not null,
+    role               enum ('ROLE_ADMIN', 'ROLE_GUEST', 'ROLE_USER') not null,
+    social_provider    enum ('GOOGLE', 'KAKAO')                       null
+);
+
+create table baguni_db.folder
+(
+    created_at         datetime(6)                                             not null,
+    id                 bigint auto_increment
+        primary key,
+    parent_folder_id   bigint                                                  null,
+    updated_at         datetime(6)                                             not null,
+    user_id            bigint                                                  not null,
+    child_folder_order longblob                                                not null,
+    name               varchar(255)                                            not null,
+    pick_order         longblob                                                not null,
+    folder_type        enum ('GENERAL', 'RECYCLE_BIN', 'ROOT', 'UNCLASSIFIED') not null,
+    constraint FK57g7veis1gp5wn3g0mp0x57pl
+        foreign key (parent_folder_id) references baguni_db.folder (id)
+            on delete cascade,
+    constraint FK5fd2civdi8s832iyrufpk400k
+        foreign key (user_id) references baguni_db.user (id)
+);
+
+create table baguni_db.pick
+(
+    created_at       datetime(6)  not null,
+    id               bigint auto_increment
+        primary key,
+    link_id          bigint       not null,
+    parent_folder_id bigint       not null,
+    updated_at       datetime(6)  not null,
+    user_id          bigint       not null,
+    tag_order        longblob     not null,
+    title            varchar(255) not null,
+    constraint FKbilrp2m7mc9ssut5d85loj5d7
+        foreign key (user_id) references baguni_db.user (id),
+    constraint FKf3o2jbamw9l96i1lwvaytuik7
+        foreign key (link_id) references baguni_db.link (id),
+    constraint FKhfrafg7f40ym7wgrtp9j45pha
+        foreign key (parent_folder_id) references baguni_db.folder (id)
+);
+
+create table baguni_db.shared_folder
+(
+    created_at datetime(6) not null,
+    folder_id  bigint      not null,
+    updated_at datetime(6) not null,
+    user_id    bigint      not null,
+    id         binary(16)  not null
+        primary key,
+    constraint UK5p0agkwypm465pveqn7na9tig
+        unique (folder_id),
+    constraint FK34v8mqhr9a6rwep0hi9aegr79
+        foreign key (user_id) references baguni_db.user (id),
+    constraint FK8xepmn10i8pgw3w1rwuffwynp
+        foreign key (folder_id) references baguni_db.folder (id)
+);
+
+create table baguni_db.tag
+(
+    color_number int          not null,
+    id           bigint auto_increment
+        primary key,
+    user_id      bigint       not null,
+    name         varchar(255) not null,
+    constraint UC_TAG_NAME_PER_USER
+        unique (user_id, name),
+    constraint FKld85w5kr7ky5w4wda3nrdo0p8
+        foreign key (user_id) references baguni_db.user (id)
+);
+
+create table baguni_db.pick_tag
+(
+    id      bigint auto_increment
+        primary key,
+    pick_id bigint not null,
+    tag_id  bigint not null,
+    constraint UC_PICK_TAG
+        unique (pick_id, tag_id),
+    constraint FK9e42g0lyb0ss1pjhvdrqqh0a8
+        foreign key (tag_id) references baguni_db.tag (id),
+    constraint FKcbtnw1dxhgh641h8yjp9nwnav
+        foreign key (pick_id) references baguni_db.pick (id)
+);
+

--- a/backend/baguni-entity/src/main/resources/db/migration/V2__add_user_idToken.sql
+++ b/backend/baguni-entity/src/main/resources/db/migration/V2__add_user_idToken.sql
@@ -1,0 +1,11 @@
+ALTER TABLE baguni_db.user
+    ADD id_token char(36);
+
+UPDATE baguni_db.user
+SET id_token = uuid();
+
+ALTER TABLE baguni_db.user
+    MODIFY id_token char(36) NOT NULL;
+
+ALTER TABLE baguni_db.user
+    ADD CONSTRAINT UKhsxhy38v8pbjsyvvql9y962ie UNIQUE (id_token);


### PR DESCRIPTION
- Close #912 

## What is this PR? 🔍

- 기능 : 
    - flyway 추가
    - 이제 local도 ddl-auto는 validate / none만 사용합니다.
        - flyway가 을 `db.migration` 디렉토리에 있는 sql 스크립트를 버전대로 실행합니다.
             - :card_file_box: `ddl-auto: update` 에 버전 관리가 추가된 느낌...? 
        - 이제 모든 db 변경 사항은 sql 스크립트로 작성해야 합니다. 
- 추가 공유 :
    - 이 PR이 도입되면, 운영 환경 DB에 따로 접속해서 업데이트 안해도 됨.
    - 현재 DB 스키마랑 flyway 스키마랑 비교해서, 다른 부분만 순차적으로 적용함
    - 참고 이미지  (`프로그램 시작할 때 실행되는 로그`)
        ![image](https://github.com/user-attachments/assets/da8f699d-3fbc-4bf3-8bd7-e503754e93c2)
    - flyway가 mysql에 추가 생성한 테이블
       ![image](https://github.com/user-attachments/assets/55760899-f9f8-4437-a359-ac796fc4a328)
 
- issue : #912 

#### :warning: 
![image](https://github.com/user-attachments/assets/e3234ce2-dc40-406b-922e-04b049803746)
 위 baseline-on-migrate 옵션은 나중에 꺼야 할 것 같은데, 조금 더 찾아보겠습니다.
https://documentation.red-gate.com/fd/baseline-on-migrate-224919695.html
