### PR TITLE
[FIX] 길이가 짧은 폴더 공유 시 공유 취소 버튼이 짤리는 문제 수정

### DIFF
--- a/frontend/techpick/src/components/MyPage/myPageShareFolderField.css.ts
+++ b/frontend/techpick/src/components/MyPage/myPageShareFolderField.css.ts
@@ -6,6 +6,7 @@ export const myPageContentContainer = style({
   display: 'grid',
   gridTemplateColumns: '15% 75% 10%',
   alignItems: 'center',
+  minWidth: '700px',
   padding: '8px',
   fontSize: fontSize.sm,
 });

--- a/frontend/techpick/src/hooks/useMyShareFolder.ts
+++ b/frontend/techpick/src/hooks/useMyShareFolder.ts
@@ -22,7 +22,7 @@ export function useMyShareFolder() {
   }, [checkIsShareFolder, treeDataMap]);
 
   const handleDeleteMyShareFolder = async (sourceFolderId: number) => {
-    const deleteAcceessToken = treeDataMap[sourceFolderId].folderAccessToken;
+    const deleteAccessToken = treeDataMap[sourceFolderId].folderAccessToken;
 
     updateFolderAccessTokenByFolderId(sourceFolderId, null);
     notifySuccess('공유 폴더가 삭제되었습니다.');
@@ -30,7 +30,7 @@ export function useMyShareFolder() {
       await deleteMyShareFolder(sourceFolderId);
     } catch {
       notifyError('공유 폴더 삭제에 실패했습니다.');
-      updateFolderAccessTokenByFolderId(sourceFolderId, deleteAcceessToken);
+      updateFolderAccessTokenByFolderId(sourceFolderId, deleteAccessToken);
     }
   };
 


### PR DESCRIPTION
- Close #926 

## What is this PR? 🔍

기능 :
폴더명이 짧을 때 버튼이 잘리는 경우가 있었습니다. 해당 문제는 그리드를 이용해 비율을 퍼센트로 나누는 것이 문제였습니다. (해당 버튼에게 주어진 width와 버튼의 width보다 작았을 때 발생했습니다.) 따라서 minWidth를 부여함으로써 해결했습니다.
- issue : #926 

## Changes 📝

## ScreenShot 📷
<img width="759" alt="스크린샷 2025-01-08 오후 4 32 53" src="https://github.com/user-attachments/assets/4349d44c-3f9b-458a-bcc9-a861be841c98" />

<!--

이번 PR에서의 변경점

| Before                     | After                     |
| -------------------------- | ------------------------- |
| ![Before Image](링크_넣기) | ![After Image](링크_넣기) |
-->

## Precaution

<!-- ## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint` -->
