### PR TITLE
[FEAT] dnd 충돌 알고리즘 수정

### DIFF
--- a/frontend/techpick/src/components/FolderAndPickDndContextProvider.tsx
+++ b/frontend/techpick/src/components/FolderAndPickDndContextProvider.tsx
@@ -2,10 +2,13 @@
 
 import { useState } from 'react';
 import type { PropsWithChildren } from 'react';
-import { DndContext, pointerWithin } from '@dnd-kit/core';
+import { DndContext } from '@dnd-kit/core';
 import { useGetDndContextSensor } from '@/hooks';
+import { pointerWithinWithClosestCenter } from '@/utils';
 import { DndMonitorContext } from './DndMonitorContext';
 import { DargOverlay } from './DragOverlay/DragOverlay';
+
+// pointerWithinWithClosestCenter
 
 /**
  * @description pick과 folder에서 drag & drop을 이용할 시에 콘텐스트로 감싸줘야합니다.
@@ -22,7 +25,10 @@ export function FolderAndPickDndContextProvider({
   });
 
   return (
-    <DndContext sensors={sensors} collisionDetection={pointerWithin}>
+    <DndContext
+      sensors={sensors}
+      collisionDetection={pointerWithinWithClosestCenter}
+    >
       <DndMonitorContext>{children}</DndMonitorContext>
       <DargOverlay elementClickPosition={elementClickPosition} />
     </DndContext>

--- a/frontend/techpick/src/utils/index.ts
+++ b/frontend/techpick/src/utils/index.ts
@@ -21,3 +21,4 @@ export { setItemToLocalStorage } from './setItemToLocalStorage';
 export { isMacOS } from './isMacOS';
 export { isLoginUser } from './isLoginUser';
 export { getUserIdForServer } from './getUserIdForServer';
+export { pointerWithinWithClosestCenter } from './pointerWithinWithClosestCenter';

--- a/frontend/techpick/src/utils/pointerWithinWithClosestCenter.ts
+++ b/frontend/techpick/src/utils/pointerWithinWithClosestCenter.ts
@@ -1,0 +1,18 @@
+'use client';
+
+import { pointerWithin, closestCenter } from '@dnd-kit/core';
+import type { CollisionDetection } from '@dnd-kit/core';
+
+/**
+ * dnd-kit의 충돌 알고리즘을 custom 합니다.
+ * pointerWithin을 수행하고 만약 마우스가 있는 영역에 Dropzone이 없으면 closestCenter가 동작합니다.
+ */
+export const pointerWithinWithClosestCenter: CollisionDetection = (args) => {
+  const pointerCollisions = pointerWithin(args);
+
+  if (pointerCollisions.length > 0) {
+    return pointerCollisions;
+  }
+
+  return closestCenter(args);
+};


### PR DESCRIPTION
- Close #ISSUE_NUMBER

## What is this PR? 🔍

- 기능 : 
- issue : #827 

## Changes 📝
드래그 앤 드랍 충돌 알고리즘을 변경했습니다.
이전의 `pointerWithin`은 마우스의 위치만 추적하느라, 아래의 gif처럼 쭉 아래로 땡겼을 때 아래로 정렬이 아닌 원래 자리로 돌아갔습니다.
그리고 `closestCenter`는  쭉 아래로 땡겼을 때 아래로 이동할 수 있었지만 북마크를 폴더로 이동할 수 없었습니다. 
따라서 drop이 가능한 영역에서는 `pointerWithin` 으로 세밀하게 조정이 되고 그렇지 않은 경우에는 `closestCenter`로 자연스러운 동작이 구현되게 하였습니다.


## ScreenShot 📷
| Before                     | After                     |
| -------------------------- | ------------------------- |
| ![before](https://github.com/user-attachments/assets/4393e15e-575c-4373-84fc-1c0d13cb2f1f) | ![after](https://github.com/user-attachments/assets/13c93811-dfb0-49e7-a4e0-37bc7550e369) |



<!--
## ScreenShot 📷
이번 PR에서의 변경점

| Before                     | After                     |
| -------------------------- | ------------------------- |
| ![Before Image](링크_넣기) | ![After Image](링크_넣기) |
-->

## Precaution

<!-- ## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint` -->
