### PR TITLE
[FIX] 웹에서 태그 생성 후 빈 태그가 생성이 가능한 문제 해결

### DIFF
--- a/frontend/techpick/src/components/PickRecord/SharePickRecord.tsx
+++ b/frontend/techpick/src/components/PickRecord/SharePickRecord.tsx
@@ -124,7 +124,7 @@ export function SharePickRecord({
 }
 
 interface SharePickRecordProps {
-  pickInfo: components['schemas']['baguni.api.service.sharedFolder.dto.SharedFolderResult$SharedPickInfo'];
-  tagList: components['schemas']['baguni.api.service.sharedFolder.dto.SharedFolderResult$SharedTagInfo'][];
+  pickInfo: components['schemas']['baguni.domain.infrastructure.sharedFolder.dto.SharedFolderResult$SharedPickInfo'];
+  tagList: components['schemas']['baguni.domain.infrastructure.sharedFolder.dto.SharedFolderResult$SharedTagInfo'][];
   folderAccessToken: string;
 }

--- a/frontend/techpick/src/components/PickTagPicker/PickTagAutocompleteDialog.tsx
+++ b/frontend/techpick/src/components/PickTagPicker/PickTagAutocompleteDialog.tsx
@@ -67,8 +67,17 @@ export function PickTagAutocompleteDialog({
     });
   };
 
+  const checkIsCreatableTag = (value: string) => {
+    const isUnique = !tagList.some((tag) => tag.name === value.trim());
+    const isNotInitialValue = value.trim() !== '';
+    const isCreatable = isUnique && isNotInitialValue;
+
+    setCanCreateTag(isCreatable);
+  };
+
   const clearTagInputValue = () => {
     setTagInputValue('');
+    checkIsCreatableTag('');
   };
 
   const onSelectTag = (tag: TagType) => {
@@ -121,14 +130,6 @@ export function PickTagAutocompleteDialog({
         tagIdOrderedList: newTagIdOrderedList,
       });
     }
-  };
-
-  const checkIsCreatableTag = (value: string) => {
-    const isUnique = !tagList.some((tag) => tag.name === value.trim());
-    const isNotInitialValue = value.trim() !== '';
-    const isCreatable = isUnique && isNotInitialValue;
-
-    setCanCreateTag(isCreatable);
   };
 
   useEffect(


### PR DESCRIPTION
- Close #ISSUE_NUMBER

## What is this PR? 🔍

기능 :
해당 버그는 @sangwonsheep 님께서 보고해주셨습니다.
문제의 원인은 인풋의 값이 바뀔 때는 계속 생성될 수 있는지 값을 확인하지만 생성 혹은 선택을 할 때, 인풋의 값을 초기화하며 생성 여부를 파악하지 않았기 때문이었습니다. 
따라서 인풋의 값이 바뀌면서 생성 여부를 판단하는 함수도 동작하게 했기에 버그가 생기지 않습니다.
- issue : #849 

## Changes 📝

<!--
## ScreenShot 📷
이번 PR에서의 변경점

| Before                     | After                     |
| -------------------------- | ------------------------- |
| ![Before Image](링크_넣기) | ![After Image](링크_넣기) |
-->

## Precaution

<!-- ## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint` -->
