### PR TITLE
[FEAT] 서버 에러 발생 시 슬랙 알림 기능 구현

### DIFF
--- a/backend/baguni-common/build.gradle
+++ b/backend/baguni-common/build.gradle
@@ -17,6 +17,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-amqp'
     implementation 'org.springframework.amqp:spring-amqp:3.2.0'
 
+    // Slack API
+    implementation 'com.slack.api:slack-api-client:1.45.1'
+
     // selenium for opengraph
     implementation 'org.seleniumhq.selenium:selenium-java:4.25.0'
     implementation 'io.github.bonigarcia:webdrivermanager:5.8.0'

--- a/backend/baguni-common/src/main/java/baguni/common/config/RabbitmqConfig.java
+++ b/backend/baguni-common/src/main/java/baguni/common/config/RabbitmqConfig.java
@@ -70,7 +70,7 @@ public class RabbitmqConfig {
 		return BindingBuilder
 			.bind(pickRanking)
 			.to(directExchange)
-			.with("ranking"); // 라우팅 키는  필요 없음
+			.with("ranking"); // 라우팅 키
 	}
 
 	@Bean
@@ -78,7 +78,7 @@ public class RabbitmqConfig {
 		return BindingBuilder
 			.bind(pickCrawling)
 			.to(directExchange)
-			.with("crawling"); // 라우팅 키는  필요 없음
+			.with("crawling"); // 라우팅 키
 	}
 
 	@Bean
@@ -86,7 +86,7 @@ public class RabbitmqConfig {
 		return BindingBuilder
 			.bind(slackNotification)
 			.to(directExchange)
-			.with("slack");
+			.with("slack"); // 라우팅 키
 	}
 
 	/**

--- a/backend/baguni-common/src/main/java/baguni/common/config/RabbitmqConfig.java
+++ b/backend/baguni-common/src/main/java/baguni/common/config/RabbitmqConfig.java
@@ -17,13 +17,13 @@ import org.springframework.context.annotation.Configuration;
 public class RabbitmqConfig {
 
 	public static final class EXCHANGE {
-		public static final String RANKING_EVENT = "exchange.ranking-event";
-		public static final String CRAWLING_EVENT = "exchange.crawling-event";
+		public static final String EVENT = "exchange.event";
 	}
 
 	public static final class QUEUE {
 		public static final String PICK_RANKING = "queue.pick-ranking";
 		public static final String PICK_CRAWLING = "queue.pick-crawling";
+		public static final String SLACK_NOTIFICATION = "queue.slack-notification";
 	}
 
 	@Value("${spring.application.name}")
@@ -41,13 +41,8 @@ public class RabbitmqConfig {
 	/**
 	 * 1. Exchange 구성 */
 	@Bean
-	DirectExchange rankingDirectExchange() {
-		return new DirectExchange(EXCHANGE.RANKING_EVENT);
-	}
-
-	@Bean
-	DirectExchange crawlingDirectExchange() {
-		return new DirectExchange(EXCHANGE.CRAWLING_EVENT);
+	DirectExchange directExchange() {
+		return new DirectExchange(EXCHANGE.EVENT);
 	}
 
 	/**
@@ -62,23 +57,36 @@ public class RabbitmqConfig {
 		return new Queue(QUEUE.PICK_CRAWLING, false);
 	}
 
+	@Bean
+	Queue slackNotification() {
+		return new Queue(QUEUE.SLACK_NOTIFICATION, false);
+	}
+
 
 	/**
 	 * 3. 큐와 DirectExchange를 바인딩 */
 	@Bean
-	Binding rankingDirectBinding(DirectExchange rankingDirectExchange, Queue pickRanking) {
+	Binding rankingDirectBinding(DirectExchange directExchange, Queue pickRanking) {
 		return BindingBuilder
 			.bind(pickRanking)
-			.to(rankingDirectExchange)
-			.with(""); // 라우팅 키는  필요 없음
+			.to(directExchange)
+			.with("ranking"); // 라우팅 키는  필요 없음
 	}
 
 	@Bean
-	Binding crawlingDirectBinding(DirectExchange crawlingDirectExchange, Queue pickCrawling) {
+	Binding crawlingDirectBinding(DirectExchange directExchange, Queue pickCrawling) {
 		return BindingBuilder
 			.bind(pickCrawling)
-			.to(crawlingDirectExchange)
-			.with(""); // 라우팅 키는  필요 없음
+			.to(directExchange)
+			.with("crawling"); // 라우팅 키는  필요 없음
+	}
+
+	@Bean
+	Binding slackNotificationBinding(DirectExchange directExchange, Queue slackNotification) {
+		return BindingBuilder
+			.bind(slackNotification)
+			.to(directExchange)
+			.with("slack");
 	}
 
 	/**

--- a/backend/baguni-common/src/main/java/baguni/common/config/RabbitmqConfig.java
+++ b/backend/baguni-common/src/main/java/baguni/common/config/RabbitmqConfig.java
@@ -70,7 +70,7 @@ public class RabbitmqConfig {
 		return BindingBuilder
 			.bind(pickRanking)
 			.to(directExchange)
-			.with("ranking"); // 라우팅 키
+			.with("ranking"); // directExchange 에 ranking 라우팅 키를 가진 메시지가 있으면 pickRanking 큐에 메시지 전달
 	}
 
 	@Bean
@@ -78,7 +78,7 @@ public class RabbitmqConfig {
 		return BindingBuilder
 			.bind(pickCrawling)
 			.to(directExchange)
-			.with("crawling"); // 라우팅 키
+			.with("crawling");
 	}
 
 	@Bean
@@ -86,7 +86,7 @@ public class RabbitmqConfig {
 		return BindingBuilder
 			.bind(slackNotification)
 			.to(directExchange)
-			.with("slack"); // 라우팅 키
+			.with("slack");
 	}
 
 	/**

--- a/backend/baguni-common/src/main/java/baguni/common/event/events/ErrorLogEvent.java
+++ b/backend/baguni-common/src/main/java/baguni/common/event/events/ErrorLogEvent.java
@@ -1,0 +1,30 @@
+package baguni.common.event.events;
+
+import lombok.Getter;
+
+@Getter
+public class ErrorLogEvent extends Event {
+
+	private final String exceptionClass; // Exception 종류
+	private final String exceptionMessage; // 예외 메세지
+	private final String requestUri; // ex) /api/picks
+	private final String requestMethod; // ex) GET, POST
+	private final String requestTime; // 예외 발생 시간
+	private final String requestAddress; // IP
+	private final String profile; // local, dev, prod 구분
+	private final int httpStatusCode; // 응답 상태 코드 ex) 500
+	private final String httpStatusMessage; // 응답 상태 메세지 ex) INTERNAL SERVER ERROR
+
+	public ErrorLogEvent(String exceptionClass, String exceptionMessage, String requestUri, String requestMethod,
+		String requestAddress, String profile, int httpStatusCode, String httpStatusMessage) {
+		this.exceptionClass = exceptionClass;
+		this.exceptionMessage = exceptionMessage;
+		this.requestUri = requestUri;
+		this.requestMethod = requestMethod;
+		this.httpStatusCode = httpStatusCode;
+		this.requestTime = super.getTimeFormatted();
+		this.requestAddress = requestAddress;
+		this.profile = profile;
+		this.httpStatusMessage = httpStatusMessage;
+	}
+}

--- a/backend/baguni-common/src/main/java/baguni/common/event/events/Event.java
+++ b/backend/baguni-common/src/main/java/baguni/common/event/events/Event.java
@@ -1,6 +1,7 @@
 package baguni.common.event.events;
 
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 import lombok.Getter;
 
@@ -13,4 +14,9 @@ public abstract class Event {
 
 	/** 이벤트가 발생한 시각 */
 	private final LocalDateTime time = LocalDateTime.now();
+
+	/** 기본 포맷: yyyy-MM-dd HH:mm:ss */
+	public String getTimeFormatted() {
+		return time.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+	}
 }

--- a/backend/baguni-common/src/main/java/baguni/common/event/listener/SlackNotificationEventListener.java
+++ b/backend/baguni-common/src/main/java/baguni/common/event/listener/SlackNotificationEventListener.java
@@ -1,0 +1,69 @@
+package baguni.common.event.listener;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+import org.springframework.amqp.rabbit.annotation.RabbitHandler;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import com.slack.api.Slack;
+import com.slack.api.model.Attachment;
+import com.slack.api.model.Field;
+import com.slack.api.webhook.Payload;
+
+import baguni.common.config.RabbitmqConfig;
+import baguni.common.event.events.ErrorLogEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 	@author sangwon
+ * 	메세지 큐에서 이벤트를 꺼내서 슬랙에 알림을 보내는 클래스
+ * 	Webhook url에 post 요청을 보내면 슬랙에 알림이 가는 시스템
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@RabbitListener(queues = {RabbitmqConfig.QUEUE.SLACK_NOTIFICATION})
+public class SlackNotificationEventListener {
+
+	private final Slack slack = Slack.getInstance();
+
+	@Value("${slack.webhook.url}")
+	private String webhookUrl;
+
+	@RabbitHandler
+	public void sendSlackMessage(ErrorLogEvent event) {
+		Attachment attachment = new Attachment();
+		attachment.setFallback("Error");
+		attachment.setColor("danger"); // 슬랙 메세지 색상
+
+		Field[] fields = new Field[] {
+			Field.builder().title("요청 시간").value(event.getRequestTime()).build(),
+			Field.builder().title("Request Method + URI").value(event.getRequestMethod() + " " + event.getRequestUri()).build(),
+			Field.builder().title("응답 코드").value(event.getHttpStatusCode() + " " + event.getHttpStatusMessage()).build(),
+			Field.builder().title("Exception 종류").value(event.getExceptionClass()).build(),
+			Field.builder().title("예외 메시지").value(event.getExceptionMessage()).build(),
+			Field.builder().title("Request IP").value(event.getRequestAddress()).build(),
+			Field.builder().title("Profile 정보").value(event.getProfile()).build()
+		};
+		attachment.setFields(Arrays.asList(fields));
+
+		// 슬랙 알림에 어떤 데이터를 보여줄 지 정하는 곳
+		// 이미지와 이름은 웹 훅에서 설정해두었기 때문에 생략
+		Payload payload = Payload.builder()
+			.text("[서버 에러 발생]") // 에러 제목
+			.attachments(List.of(attachment)) // Field에 지정한 메세지들
+			.build();
+
+		try {
+			// 슬랙에 알림을 보내는 부분
+			slack.send(webhookUrl, payload);
+		} catch (IOException e) {
+			log.error("슬랙 알림 전송 실패 : {}", e.getMessage(), e);
+		}
+	}
+}

--- a/backend/baguni-common/src/main/java/baguni/common/event/listener/SlackNotificationEventListener.java
+++ b/backend/baguni-common/src/main/java/baguni/common/event/listener/SlackNotificationEventListener.java
@@ -55,7 +55,7 @@ public class SlackNotificationEventListener {
 		// 슬랙 알림에 어떤 데이터를 보여줄 지 정하는 곳
 		// 이미지와 이름은 웹 훅에서 설정해두었기 때문에 생략
 		Payload payload = Payload.builder()
-			.text("[서버 에러 발생]") // 에러 제목
+			.text(":rotating_light: [서버 에러 발생] :rotating_light:") // 에러 제목
 			.attachments(List.of(attachment)) // Field에 지정한 메세지들
 			.build();
 

--- a/backend/baguni-common/src/main/java/baguni/common/event/messenger/CrawlingEventMessenger.java
+++ b/backend/baguni-common/src/main/java/baguni/common/event/messenger/CrawlingEventMessenger.java
@@ -19,7 +19,7 @@ public class CrawlingEventMessenger implements EventMessenger {
 	@Override
 	public void send(Event event) {
 		try {
-			rabbitTemplate.convertAndSend(RabbitmqConfig.EXCHANGE.CRAWLING_EVENT, "", event);
+			rabbitTemplate.convertAndSend(RabbitmqConfig.EXCHANGE.EVENT, "crawling", event);
 		} catch (AmqpException e) {
 			log.error(e.getMessage(), e);
 		}

--- a/backend/baguni-common/src/main/java/baguni/common/event/messenger/RankingEventMessenger.java
+++ b/backend/baguni-common/src/main/java/baguni/common/event/messenger/RankingEventMessenger.java
@@ -21,8 +21,8 @@ public class RankingEventMessenger implements EventMessenger {
 	@Override
 	public void send(Event event) {
 		try {
-			rabbitTemplate.convertAndSend(RabbitmqConfig.EXCHANGE.RANKING_EVENT, "", event);
-			log.info("이벤트 전송 {}", event);
+			rabbitTemplate.convertAndSend(RabbitmqConfig.EXCHANGE.EVENT, "ranking", event);
+			log.info("이벤트 전송 {} : ", event);
 		} catch (AmqpException e) {
 			log.error(e.getMessage(), e);
 		}

--- a/backend/baguni-common/src/main/java/baguni/common/event/messenger/SlackNotificationEventMessenger.java
+++ b/backend/baguni-common/src/main/java/baguni/common/event/messenger/SlackNotificationEventMessenger.java
@@ -1,0 +1,34 @@
+package baguni.common.event.messenger;
+
+import org.springframework.amqp.AmqpException;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.stereotype.Component;
+
+import baguni.common.config.RabbitmqConfig;
+import baguni.common.event.events.Event;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ *  @author sangwon
+ * 	현재, EventMessenger 인터페이스의 구현 클래스가 여러 개 생성되고 있음.
+ * 	인터페이스를 의존하고 싶어도 구현 클래스가 여러 개가 되면서 어떤 것을 빈 주입해야 할 지 알 수 없어짐.
+ *  Qualifier 쓰거나 구현체를 직접 사용하는 방식이 있을 것이다.
+ * 	TODO: 지금처럼 여러 클래스를 사용할 것인가? 아니면 EventMessenger 에서 여러 메서드로 분리할 것인가?
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SlackNotificationEventMessenger implements EventMessenger {
+
+	private final RabbitTemplate rabbitTemplate;
+
+	@Override
+	public void send(Event event) {
+		try {
+			rabbitTemplate.convertAndSend(RabbitmqConfig.EXCHANGE.EVENT, "slack", event);
+		} catch (AmqpException e) {
+			log.error(e.getMessage(), e);
+		}
+	}
+}

--- a/backend/baguni-common/src/main/java/baguni/common/exception/base/ApiExceptionHandler.java
+++ b/backend/baguni-common/src/main/java/baguni/common/exception/base/ApiExceptionHandler.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import baguni.common.exception.level.FatalErrorLevel;
-import baguni.common.util.SlackNotificationService;
+import baguni.common.util.ErrorLogEventBuilder;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import baguni.common.exception.level.ErrorLevel;
@@ -20,7 +20,7 @@ import baguni.common.util.RequestHolder;
 public class ApiExceptionHandler {
 
 	private final RequestHolder requestHolder;
-	private final SlackNotificationService slackNotificationService;
+	private final ErrorLogEventBuilder errorLogEventBuilder;
 
 	/**
 	 * ApiException 에서 잡지 못한 예외는
@@ -29,7 +29,7 @@ public class ApiExceptionHandler {
 	@ExceptionHandler(Exception.class)
 	public ApiErrorResponse handleGlobalException(Exception exception) {
 		ErrorLevel.MUST_NEVER_HAPPEN().handleError(exception, requestHolder.getRequest());
-		slackNotificationService.sendSlackMessage(exception, HttpStatus.INTERNAL_SERVER_ERROR);
+		errorLogEventBuilder.sendSlackMessage(exception, HttpStatus.INTERNAL_SERVER_ERROR);
 		return ApiErrorResponse.UNKNOWN_SERVER_ERROR();
 	}
 
@@ -41,7 +41,7 @@ public class ApiExceptionHandler {
 		ApiErrorCode apiErrorCode = exception.getApiErrorCode();
 		ErrorLevel errorLevel = apiErrorCode.getErrorLevel();
 		if (errorLevel instanceof FatalErrorLevel) {
-			slackNotificationService.sendSlackMessage(exception, apiErrorCode.getHttpStatus());
+			errorLogEventBuilder.sendSlackMessage(exception, apiErrorCode.getHttpStatus());
 		}
 
 		exception.handleErrorByLevel(requestHolder.getRequest());

--- a/backend/baguni-common/src/main/java/baguni/common/util/ErrorLogEventBuilder.java
+++ b/backend/baguni-common/src/main/java/baguni/common/util/ErrorLogEventBuilder.java
@@ -19,7 +19,7 @@ import lombok.RequiredArgsConstructor;
  */
 @Component
 @RequiredArgsConstructor
-public class SlackNotificationService {
+public class ErrorLogEventBuilder {
 
 	private final RequestHolder requestHolder;
 	private final Environment environment; // Profile 정보 얻기 위한 클래스

--- a/backend/baguni-common/src/main/java/baguni/common/util/SlackNotificationService.java
+++ b/backend/baguni-common/src/main/java/baguni/common/util/SlackNotificationService.java
@@ -1,0 +1,43 @@
+package baguni.common.util;
+
+import java.util.Arrays;
+
+import org.springframework.core.env.Environment;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+
+import baguni.common.event.events.ErrorLogEvent;
+import baguni.common.event.messenger.SlackNotificationEventMessenger;
+import baguni.common.exception.base.ApiException;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 	@author sangwon
+ * 	ExceptionHandler에서 슬랙 알림 이벤트를 발행하기 위한 클래스
+ * 	Exception, ApiException 오버로딩을 통해 에러 메세지 형식을 맞춤.
+ * 	요청, 응답에 대한 데이터를 메세지 큐에 전달
+ */
+@Component
+@RequiredArgsConstructor
+public class SlackNotificationService {
+
+	private final RequestHolder requestHolder;
+	private final Environment environment; // Profile 정보 얻기 위한 클래스
+	private final SlackNotificationEventMessenger eventMessenger;
+
+	public void sendSlackMessage(Exception e, HttpStatus httpStatus) {
+		CachedHttpServletRequest request = requestHolder.getRequest();
+		ErrorLogEvent event = new ErrorLogEvent(e.getClass().getCanonicalName(), e.getMessage(),
+			request.getRequestURI(), request.getMethod(), request.getRemoteAddr(), Arrays.toString(environment.getActiveProfiles()), httpStatus.value(),
+			httpStatus.name());
+		eventMessenger.send(event);
+	}
+
+	public void sendSlackMessage(ApiException e, HttpStatus httpStatus) {
+		CachedHttpServletRequest request = requestHolder.getRequest();
+		ErrorLogEvent event = new ErrorLogEvent(e.getClass().getCanonicalName(), e.getApiErrorCode().getMessage(),
+			request.getRequestURI(), request.getMethod(), request.getRemoteAddr(), Arrays.toString(environment.getActiveProfiles()), httpStatus.value(),
+			httpStatus.name());
+		eventMessenger.send(event);
+	}
+}

--- a/backend/baguni-common/src/main/resources/application-common.yaml
+++ b/backend/baguni-common/src/main/resources/application-common.yaml
@@ -1,3 +1,6 @@
+slack:
+  webhook:
+    url: ${SLACK_WEBHOOK_URL}
 ---
 spring:
   config:


### PR DESCRIPTION
- Close #961

## What is this PR? 🔍

- 기능 : 서버 에러 발생 시 슬랙 알림 기능 구현
- issue : #961

## Changes 📝
### 1. RabbitMQ 개선
#928 에서 개선하기로 한 Exchange 1개에 routing key 방식으로 변경
routing key에 맞게 queue 설정
- "ranking" -> ranking queue
- "crawling" -> crawling queue
- "slack" -> slack notification queue

RabbitmqConfig 참고 부탁드립니다.

### 2. 슬랙 알림 기능
슬랙 API 라이브러리가 존재하여 사용하였습니다.
`implementation 'com.slack.api:slack-api-client:1.45.1'`

- 로그 발생하는 부분과 슬랙 알림은 비동기로 분리하여 슬랙 알림은 메세지 큐에서 처리하도록 하였습니다.

이유 : 로그 발생과 슬랙 알림 작업은 분리가 필요하다고 생각했습니다. 슬랙 관련 문제가 발생하면 리트라이나 실패 시 메세지 큐에서 처리할 수 있게 하여 정상 동작하도록 할 수 있을 것이라 생각했습니다.

- 슬랙 알림 flow

1. Exception, ApiException(`FatalErrorLevel`) 발생 
2. SlackNotificationService에서 Event 전달
3. SlackNotificationEventMessenger에서 메세지 큐 Exchange에 메세지 발행
4. SlackNotificationEventListener에서 메세지를 꺼내 webhook url로 post 요청하여 슬랙에 알림 전송

## 에러 관련 메세지
<img width="429" alt="image" src="https://github.com/user-attachments/assets/d1a87566-83b1-4b96-8078-9673fa6d9071" />

추가하고 싶은 내용이 있거나 메세지 순서를 바꾸고 싶으면 말씀해주세요!

## 참고 사이트
https://mr-popo.tistory.com/229