### PR TITLE
[REFACTOR] 추천 페이지에서 픽 중복 허용

### DIFF
--- a/backend/baguni-api/src/main/java/baguni/api/application/pick/controller/PickApiController.java
+++ b/backend/baguni-api/src/main/java/baguni/api/application/pick/controller/PickApiController.java
@@ -171,31 +171,6 @@ public class PickApiController {
 		return ResponseEntity.ok(response);
 	}
 
-	/**
-	 *	중복을 허용하게 되면서 existPick 존재 의미가 사라졌습니다.
-	 *	추후, API
-	 */
-	@PostMapping("/recommend")
-	@Operation(
-		summary = "추천 링크로 픽 생성",
-		description = "추천 링크로 픽을 생성합니다. 픽 중복 저장이 가능합니다."
-	)
-	@ApiResponses(value = {
-		@ApiResponse(responseCode = "200", description = "픽 생성 성공"),
-		@ApiResponse(responseCode = "403", description = "접근할 수 없는 폴더")
-	})
-	public ResponseEntity<PickApiResponse.CreateFromRecommend> savePickFromRecommend(
-		@LoginUserId Long userId,
-		@Valid @RequestBody PickApiRequest.Create request
-	) {
-		boolean existPick = false; // 중복 허용
-		var command = pickApiMapper.toCreateCommand(userId, request);
-		var result = pickService.saveNewPick(command);
-		var event = new PickCreateEvent(userId, result.id(), result.linkInfo().url());
-		rankingEventMessenger.send(event);
-		return ResponseEntity.ok(new PickApiResponse.CreateFromRecommend(existPick, result));
-	}
-
 	@MeasureTime
 	@PostMapping("/extension")
 	@Operation(

--- a/backend/baguni-api/src/main/java/baguni/api/application/pick/controller/PickApiController.java
+++ b/backend/baguni-api/src/main/java/baguni/api/application/pick/controller/PickApiController.java
@@ -171,10 +171,14 @@ public class PickApiController {
 		return ResponseEntity.ok(response);
 	}
 
+	/**
+	 *	중복을 허용하게 되면서 existPick 존재 의미가 사라졌습니다.
+	 *	추후, API
+	 */
 	@PostMapping("/recommend")
 	@Operation(
 		summary = "추천 링크로 픽 생성",
-		description = "추천 링크로 픽을 생성합니다. 이미 픽으로 등록된 링크의 경우 기존 픽 정보를 응답으로 보냅니다."
+		description = "추천 링크로 픽을 생성합니다. 픽 중복 저장이 가능합니다."
 	)
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "픽 생성 성공"),
@@ -184,16 +188,9 @@ public class PickApiController {
 		@LoginUserId Long userId,
 		@Valid @RequestBody PickApiRequest.Create request
 	) {
-		boolean existPick;
-		PickResult.Pick result;
-		if (pickService.existPickByUrl(userId, request.linkInfo().url())) {
-			existPick = true;
-			result = pickService.getPickUrl(userId, request.linkInfo().url());
-		} else {
-			existPick = false;
-			var command = pickApiMapper.toCreateCommand(userId, request);
-			result = pickService.saveNewPick(command);
-		}
+		boolean existPick = false; // 중복 허용
+		var command = pickApiMapper.toCreateCommand(userId, request);
+		var result = pickService.saveNewPick(command);
 		var event = new PickCreateEvent(userId, result.id(), result.linkInfo().url());
 		rankingEventMessenger.send(event);
 		return ResponseEntity.ok(new PickApiResponse.CreateFromRecommend(existPick, result));

--- a/backend/baguni-domain/src/main/java/baguni/domain/infrastructure/pick/PickDataHandler.java
+++ b/backend/baguni-domain/src/main/java/baguni/domain/infrastructure/pick/PickDataHandler.java
@@ -105,12 +105,6 @@ public class PickDataHandler {
 								  })
 								  .orElseGet(() -> linkRepository.save(linkMapper.of(command.linkInfo())));
 
-		// 픽 존재 여부 검증
-		pickRepository.findByUserAndLink(user, link)
-					  .ifPresent((__) -> {
-						  throw ApiPickException.PICK_MUST_BE_UNIQUE_FOR_A_URL();
-					  });
-
 		Pick savedPick = pickRepository.save(pickMapper.toEntity(command, user, folder, link));
 		Folder parentFolder = savedPick.getParentFolder();
 		attachPickToParentFolder(savedPick, parentFolder);


### PR DESCRIPTION
- Close #984

## What is this PR? 🔍

- 기능 : 추천 페이지에서 픽 중복 허용
- issue : #984

## Changes 📝
- `/api/picks/recommand` 사용하지 않기 때문에 삭제
- 미분류로 픽 생성하는 부분만 중복 허용되어 있었기 때문에 픽 생성 관련된 부분은 모두 중복 허용