### PR TITLE
[BUG] 순환 참조 문제 해결

### DIFF
--- a/backend/baguni-common/src/main/java/baguni/common/config/RabbitmqConfig.java
+++ b/backend/baguni-common/src/main/java/baguni/common/config/RabbitmqConfig.java
@@ -14,8 +14,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import lombok.RequiredArgsConstructor;
-
 /**
  * @see
  * <a href="https://docs.spring.io/spring-amqp/docs/1.5.1.RELEASE/reference/htmlsingle/#collection-declaration">
@@ -23,7 +21,6 @@ import lombok.RequiredArgsConstructor;
  * </a>
  */
 @Configuration
-@RequiredArgsConstructor
 public class RabbitmqConfig {
 
 	public static final class EXCHANGE {
@@ -35,8 +32,6 @@ public class RabbitmqConfig {
 		public static final String LINK_UPDATE = "queue.link-analyze";
 		public static final String SLACK_NOTIFICATION = "queue.slack-notification";
 	}
-
-	private final RabbitmqCustomErrorHandler rabbitmqCustomErrorHandler;
 
 	@Value("${spring.application.name}")
 	private String appName;
@@ -142,7 +137,8 @@ public class RabbitmqConfig {
 	 */
 	@Bean
 	public SimpleRabbitListenerContainerFactory rabbitListenerContainerFactory(
-		CachingConnectionFactory cachingConnectionFactory
+		CachingConnectionFactory cachingConnectionFactory,
+		RabbitmqCustomErrorHandler rabbitmqCustomErrorHandler
 	) {
 		var containerFactory = new SimpleRabbitListenerContainerFactory();
 		containerFactory.setConnectionFactory(cachingConnectionFactory);

--- a/backend/baguni-common/src/main/java/baguni/common/config/RabbitmqCustomErrorHandler.java
+++ b/backend/baguni-common/src/main/java/baguni/common/config/RabbitmqCustomErrorHandler.java
@@ -1,40 +1,19 @@
 package baguni.common.config;
 
 import org.springframework.amqp.rabbit.listener.ConditionalRejectingErrorHandler;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Lazy;
-import org.springframework.stereotype.Component;
 
 import baguni.common.event.messenger.EventMessenger;
 import baguni.common.exception.base.ApiException;
 import baguni.common.util.ErrorLogEventBuilder;
 import lombok.RequiredArgsConstructor;
 
-/**
- * Bean 생성 과정에서 순환 참조 발생
- * - [ RabbitMqConfig --> ErrorHandler --> EventMessenger ---> RabbitMqConfig --> ... ]
- * Ref: https://www.baeldung.com/circular-dependencies-in-spring
- *
- * 근본적으로 객체 디자인이 잘못된 거니까 수정이 필요함.
- * 그런데 일단 해결 방법은 @Lazy + Setter Injection을 통해 해결 가능.
- *
- * 추후 해당 부분을 어떻게 해결할 수 있을지 고민해볼 것.
- */
-@Component
+
 @RequiredArgsConstructor
 public class RabbitmqCustomErrorHandler extends ConditionalRejectingErrorHandler {
 
 	private final ErrorLogEventBuilder errorLogEventBuilder;
 
-	private EventMessenger eventMessenger;
-
-	/**
-	 * Lazy Injection (후추 @Lazy를 지울 수 있도록 변경 필요)
-	 */
-	@Autowired
-	public void setEventMessenger(@Lazy EventMessenger eventMessenger) {
-		this.eventMessenger = eventMessenger;
-	}
+	private final EventMessenger eventMessenger;
 
 	@Override
 	public void handleError(Throwable t) {

--- a/backend/baguni-common/src/main/java/baguni/common/config/RabbitmqErrorHandlerConfig.java
+++ b/backend/baguni-common/src/main/java/baguni/common/config/RabbitmqErrorHandlerConfig.java
@@ -1,0 +1,31 @@
+package baguni.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import baguni.common.event.messenger.EventMessenger;
+import baguni.common.util.ErrorLogEventBuilder;
+
+@Configuration
+public class RabbitmqErrorHandlerConfig {
+
+	/**
+	 * 기존에 @Component를 이용해서 자동 주입하는 경우 스프링이 빈을 누구를 먼저 만들지에 대해 꼬이게 됨.
+	 * 기존 : RabbitConfig -> RabbitmqCustomErrorHandler -> EventMessenger -> RabbitTemplate (RabbitConfig) -> RabbitmqCustomErrorHandler // 순환 구조
+	 * RabbitConfig -> RabbitmqCustomErrorHandler 연관 관계를 끊는게 필수
+	 *
+	 * RabbitmqCustomErrorHandler의 @Component를 제거하고 직접 @Configuration에서 수동으로 빈 등록하는 것으로 변경
+	 * 변경 : RabbitmqCustomErrorHandler -> EventMessenger -> RabbitTemplate (RabbitConfig) // 순환 구조 끊김
+	 *
+	 * 기존에는 RabbitConfig에서 RabbitmqCustomErrorHandler를 생성자 주입을 받았음.
+	 * 변경 후에는 RabbitmqErrorHandlerConfig에서 RabbitmqCustomErrorHandler를 빈으로 등록함.
+	 * 스프링 컨테이너에 등록되어 있기 때문에 RabbitConfig에서는 RabbitmqCustomErrorHandler를 필요할 때 컨테이너에서 꺼내서 가져다 쓰게 되어 순환 참조 해결
+	 */
+	@Bean
+	public RabbitmqCustomErrorHandler rabbitmqCustomErrorHandler(
+		ErrorLogEventBuilder errorLogEventBuilder,
+		EventMessenger eventMessenger
+	) {
+		return new RabbitmqCustomErrorHandler(errorLogEventBuilder, eventMessenger);
+	}
+}


### PR DESCRIPTION
- Close #1016

## What is this PR? 🔍

- 기능 : RabbitMQ 순환 참조 문제 해결
- issue : #1016

## Changes 📝
- `RabbitmqCustomErrorHandler`의 `@Lazy`, `@Component` 제거
- `RabbitmqErrorHandlerConfig` `@Configuration`에서 `RabbitmqCustomErrorHandler` 수동 빈으로 등록
- `RabbitmqConfig`의 `rabbitListenerContainerFactory` 메서드에서 파라미터로 받도록 변경
```java
@Bean
public SimpleRabbitListenerContainerFactory rabbitListenerContainerFactory(
    CachingConnectionFactory cachingConnectionFactory,
    RabbitmqCustomErrorHandler rabbitmqCustomErrorHandler // 추가된 부분
) {
```

이렇게 해서 순환 참조 문제 해결
- 기존 : RabbitConfig -> RabbitmqCustomErrorHandler -> EventMessenger -> RabbitTemplate (RabbitConfig) -> RabbitmqCustomErrorHandler -> ... 순환 구조
- 변경 : RabbitmqCustomErrorHandler -> EventMessenger -> RabbitTemplate (RabbitConfig) 순환 구조 끊김

RabbitConfig에서 RabbitmqCustomErrorHandler를 생성자 주입하면서 순환 구조가 발생한 것으로 파악 하였습니다.
RabbitmqCustomErrorHandler를 스프링 컨테이너에 등록해놓고, 필요할 때 마다 가져다 쓰면 됩니다.
이를 통해 RabbitConfig에서 RabbitmqCustomErrorHandler에 의존하지 않게 되면서 순환 참조 문제가 해결된 것이죠.

## Precaution
> Consumer 가 또 다른 메시지 Producer 가 될 수 있는지? 괜찮은지?

이 부분에 대해서는 consumer가 또 다른 producer가 될 수도 있을 것이라는 생각이 드네요.
에러 발생 -> producer가 발행 -> consumer가 소모 -> 에러 발생 -> producer가 발행 -> ...

지금 이런 상황이 발생할 수 있을 것이라 생각합니다.
근데 발생해도 `containerFactory.setDefaultRequeueRejected(false);` 이 코드 덕분에 막히지 않을까 생각합니다.
만약, 안막힌다면 (Dead Letter Queue 또는 재시도)가 필요할 것 같습니다.