### PR TITLE
[FEAT] Controller 테스트 구현

### DIFF
--- a/backend/baguni-api/src/main/java/baguni/api/application/pick/controller/PickApiController.java
+++ b/backend/baguni-api/src/main/java/baguni/api/application/pick/controller/PickApiController.java
@@ -103,51 +103,9 @@ public class PickApiController {
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "픽 여부 조회 성공"),
 	})
-	public ResponseEntity<PickApiResponse.Exist> getPickUrl(@LoginUserId Long userId,
+	public ResponseEntity<PickApiResponse.Exist> existPick(@LoginUserId Long userId,
 		@RequestParam String link) {
 		return ResponseEntity.ok(pickApiMapper.toApiExistResponse(pickService.existPickByUrl(userId, link)));
-	}
-
-	/**
-	 * @author minkyeu kim
-	 * 프론트엔드에서 4XX를 픽 없음으로 판단하는 로직이 불편하기 때문에
-	 * Boolean으로 픽이 있다 없다를 판단하도록 변경합니다.
-	 * 익스텐션은 구글 심사 때문에 기존 getLinkDataXXX를 이용하고, 추후 getLinkDataV2 로 교체할 예정
-	 */
-	@MeasureTime
-	@GetMapping("/link-v2")
-	@Operation(summary = "링크 픽 여부 조회 + 픽 정보 조회", description = "해당 링크를 픽한 적이 있는지 확인합니다. + 픽에 대한 정보도 반환합니다.")
-	@ApiResponses(value = {
-		@ApiResponse(responseCode = "200", description = "픽 여부 조회 성공"),
-	})
-
-	public ResponseEntity<PickApiResponse.PickExists> doesUserHasPickWithGivenUrl(
-		@LoginUserId Long userId, @RequestParam String link
-	) {
-		var response = pickService.findPickUrl(userId, link)
-								  .map(pickApiMapper::toApiResponse)
-								  .map(pick -> new PickApiResponse.PickExists(true, pick))
-								  .orElseGet(() -> new PickApiResponse.PickExists(false, null));
-		return ResponseEntity.ok(response);
-	}
-
-	@Deprecated
-	@GetMapping("/{id}")
-	@Operation(
-		summary = "[Deprecated] 픽 상세 조회",
-		description = """
-				현재 사용되지 않는 api 입니다.
-				추후 코드 제거 예정입니다.
-			"""
-	)
-	@ApiResponses(value = {
-		@ApiResponse(responseCode = "200", description = "픽 상세 조회 성공")
-	})
-	public ResponseEntity<PickApiResponse.Pick> getPick(@LoginUserId Long userId,
-		@PathVariable Long id) {
-		return ResponseEntity.ok(
-			pickApiMapper.toApiResponse(
-				pickService.getPick(pickApiMapper.toReadCommand(userId, new PickApiRequest.Read(id)))));
 	}
 
 	@PostMapping

--- a/backend/baguni-api/src/main/java/baguni/api/application/pick/dto/PickApiMapper.java
+++ b/backend/baguni-api/src/main/java/baguni/api/application/pick/dto/PickApiMapper.java
@@ -20,8 +20,6 @@ import baguni.domain.infrastructure.pick.dto.PickResult;
 )
 public interface PickApiMapper {
 
-	PickCommand.Read toReadCommand(Long userId, PickApiRequest.Read request);
-
 	PickCommand.ReadList toReadListCommand(Long userId, List<Long> folderIdList);
 
 	PickCommand.SearchPagination toSearchPaginationCommand(Long userId, List<Long> folderIdList,
@@ -29,7 +27,7 @@ public interface PickApiMapper {
 
 	PickCommand.Create toCreateCommand(Long userId, PickApiRequest.Create request);
 
-	PickCommand.Unclassified toExtensionCommand(Long userId, String title, String url);
+	PickCommand.Extension toExtensionCommand(Long userId, String title, String url);
 
 	PickCommand.Update toUpdateCommand(Long userId, PickApiRequest.UpdateFromExtension request);
 

--- a/backend/baguni-api/src/main/java/baguni/api/application/sharedFolder/controller/SharedFolderApiController.java
+++ b/backend/baguni-api/src/main/java/baguni/api/application/sharedFolder/controller/SharedFolderApiController.java
@@ -16,6 +16,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import baguni.api.application.sharedFolder.dto.SharedFolderApiMapper;
@@ -26,6 +27,7 @@ import baguni.security.annotation.LoginUserId;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/shared")
+@Tag(name = "SharedFolder API", description = "공유 폴더 API")
 public class SharedFolderApiController {
 
 	private final SharedFolderService sharedFolderService;
@@ -61,7 +63,7 @@ public class SharedFolderApiController {
 	@DeleteMapping("/{sourceFolderId}")
 	@Operation(summary = "폴더 공유 취소", description = "공유된 폴더를 비공개로 변경 합니다.")
 	@ApiResponses(value = {
-		@ApiResponse(responseCode = "200", description = "폴더 비공개화 성공"),
+		@ApiResponse(responseCode = "204", description = "폴더 비공개화 성공"),
 		@ApiResponse(responseCode = "403", description = "자신의 공유 폴더만 삭제 할 수 있습니다.")
 	})
 	public ResponseEntity<Void> deleteSharedFolder(

--- a/backend/baguni-api/src/main/java/baguni/api/application/tag/controller/TagApiController.java
+++ b/backend/baguni-api/src/main/java/baguni/api/application/tag/controller/TagApiController.java
@@ -37,7 +37,7 @@ public class TagApiController {
 	private final TagApiMapper tagApiMapper;
 
 	@GetMapping
-	@Operation(summary = "태그 조회", description = "사용자가 등록한 전체 태그를 조회합니다.")
+	@Operation(summary = "사용자 태그 조회", description = "사용자가 등록한 전체 태그를 조회합니다.")
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "조회 성공")
 	})

--- a/backend/baguni-api/src/main/java/baguni/api/application/tag/dto/TagApiMapper.java
+++ b/backend/baguni-api/src/main/java/baguni/api/application/tag/dto/TagApiMapper.java
@@ -14,8 +14,6 @@ import baguni.domain.infrastructure.tag.dto.TagResult;
 )
 public interface TagApiMapper {
 
-	TagCommand.Read toReadCommand(Long userId, TagApiRequest.Read request);
-
 	TagCommand.Create toCreateCommand(Long userId, TagApiRequest.Create request);
 
 	TagCommand.Update toUpdateCommand(Long userId, TagApiRequest.Update request);
@@ -27,6 +25,4 @@ public interface TagApiMapper {
 	TagApiResponse.Read toReadResponse(TagResult result);
 
 	TagApiResponse.Create toCreateResponse(TagResult result);
-
-	TagApiResponse.Update toUpdateResponse(TagResult result);
 }

--- a/backend/baguni-api/src/main/java/baguni/api/service/pick/service/PickService.java
+++ b/backend/baguni-api/src/main/java/baguni/api/service/pick/service/PickService.java
@@ -95,7 +95,7 @@ public class PickService {
 
 	@LoginUserIdDistributedLock
 	@Transactional
-	public PickResult.Extension savePickToUnclassified(PickCommand.Unclassified command) {
+	public PickResult.Extension savePickToUnclassified(PickCommand.Extension command) {
 		return pickMapper.toExtensionResult(pickDataHandler.savePickToUnclassified(command));
 	}
 

--- a/backend/baguni-api/src/test/java/baguni/api/application/folder/controller/FolderApiControllerTest.java
+++ b/backend/baguni-api/src/test/java/baguni/api/application/folder/controller/FolderApiControllerTest.java
@@ -1,0 +1,271 @@
+package baguni.api.application.folder.controller;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import baguni.BaguniApiApplication;
+import baguni.api.application.folder.dto.FolderApiMapper;
+import baguni.api.application.folder.dto.FolderApiMapperImpl;
+import baguni.api.application.folder.dto.FolderApiRequest;
+import baguni.api.application.folder.dto.FolderApiResponse;
+import baguni.api.application.pick.dto.PickApiMapper;
+import baguni.api.application.pick.dto.PickApiMapperImpl;
+import baguni.api.service.folder.service.FolderService;
+import baguni.api.service.sharedFolder.service.SharedFolderService;
+import baguni.api.service.user.service.UserService;
+import baguni.domain.infrastructure.folder.dto.FolderCommand;
+import baguni.domain.infrastructure.folder.dto.FolderResult;
+import baguni.domain.infrastructure.user.dto.UserInfo;
+import baguni.domain.model.folder.FolderType;
+import baguni.domain.model.util.IDToken;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@SpringBootTest(classes = BaguniApiApplication.class)
+@ActiveProfiles("local")
+@AutoConfigureMockMvc // MockMvc 사용을 위한 설정
+@Import(FolderApiMapperImpl.class) // @SpyBean 구현체 인식을 못하여 추가
+@DisplayName("폴더 컨트롤러 - 슬라이스 테스트")
+class FolderApiControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@MockBean
+	private FolderService folderService;
+
+	@MockBean
+	private SharedFolderService sharedFolderService;
+
+	@MockBean
+	private UserService userService;
+
+	@SpyBean
+	private FolderApiMapper folderApiMapper;
+
+	@MockBean
+	private SecurityFilterChain securityFilterChain; // 실제 시큐리티 구현체 사용하지 않기 위함.
+
+	Long userId, folderId, otherFolderId, rootId, unclassifiedId, recycleBinId, sharedFolderId;
+	String uuidToken;
+	IDToken idToken;
+	UserInfo userInfo;
+
+	@BeforeEach
+	void setUp() {
+		userId = 1L;
+		rootId = 1L; unclassifiedId = 2L; recycleBinId = 3L; folderId = 4L; otherFolderId = 5L;
+		sharedFolderId = 1L;
+		uuidToken = UUID.randomUUID().toString();
+
+		idToken = IDToken.fromString(UUID.randomUUID().toString());
+		var authentication = new UsernamePasswordAuthenticationToken(idToken, null,
+			List.of(new SimpleGrantedAuthority("ROLE_USER")));
+
+		// @LoginUserId에서 사용하므로 임의의 데이터 세팅
+		SecurityContextHolder.getContext().setAuthentication(authentication);
+
+		userInfo = new UserInfo(userId, "user", idToken, "email@example.com");
+
+		// 반드시 있어야 합니다. userInfo 객체를 인식합니다.
+		given(userService.getUserInfoByToken(idToken)).willReturn(userInfo);
+	}
+
+	@AfterEach
+	void cleanUp() {
+		// 설정했던 시큐리티 데이터 제거
+		SecurityContextHolder.clearContext();
+	}
+
+	@Test
+	@DisplayName("루트 폴더와 하위 리스트 조회")
+	void all_root_folder() throws Exception {
+		// given
+		List<FolderResult> folderResultList = List.of(
+			new FolderResult(rootId, "root", FolderType.ROOT, null, List.of(folderId, otherFolderId), new ArrayList<>(), LocalDateTime.now(), LocalDateTime.now()),
+			new FolderResult(folderId, "폴더1", FolderType.GENERAL, rootId, new ArrayList<>(), new ArrayList<>(), LocalDateTime.now(), LocalDateTime.now()),
+			new FolderResult(otherFolderId, "폴더2", FolderType.GENERAL, rootId, new ArrayList<>(), new ArrayList<>(), LocalDateTime.now(), LocalDateTime.now())
+		);
+
+		for (FolderResult folderResult : folderResultList) {
+			String folderAccessToken = UUID.randomUUID().toString();
+			Optional<String> optionalAccessToken = Optional.of(folderAccessToken);
+			given(sharedFolderService.findFolderAccessTokenByFolderId(folderResult.id())).willReturn(optionalAccessToken);
+		}
+
+		given(folderService.getAllRootFolderList(userId)).willReturn(folderResultList);
+
+		// when
+		mockMvc.perform(get("/api/folders")
+				   .header("Authorization", "test-token")
+				   .contentType(MediaType.APPLICATION_JSON))
+			   .andExpect(status().isOk());
+
+		// then
+		then(sharedFolderService).should(times(3)).findFolderAccessTokenByFolderId(any());
+		then(folderService).should(times(1)).getAllRootFolderList(userId);
+		then(folderApiMapper).should(times(3)).toApiResponse(any(), any());
+
+		folderApiMapper.toApiResponse(null, null);
+		folderApiMapper.toApiResponse(new FolderResult(folderId, "폴더1", FolderType.GENERAL, rootId, new ArrayList<>(), new ArrayList<>(), LocalDateTime.now(), LocalDateTime.now()), null);
+		folderApiMapper.toApiResponse(null, uuidToken);
+		folderApiMapper.toApiResponse(new FolderResult(rootId, "root", FolderType.ROOT, null, null, null, LocalDateTime.now(), LocalDateTime.now()), null);
+	}
+
+	@Test
+	@DisplayName("기본 폴더 리스트 조회")
+	void basic_folder() throws Exception {
+		// given
+		List<FolderResult> folderResultList = List.of(
+			new FolderResult(rootId, "root", FolderType.ROOT, null, new ArrayList<>(), new ArrayList<>(), LocalDateTime.now(), LocalDateTime.now()),
+			new FolderResult(unclassifiedId, "unclassified", FolderType.UNCLASSIFIED, null, new ArrayList<>(), new ArrayList<>(), LocalDateTime.now(), LocalDateTime.now()),
+			new FolderResult(recycleBinId, "recycleBin", FolderType.RECYCLE_BIN, null, new ArrayList<>(), new ArrayList<>(), LocalDateTime.now(), LocalDateTime.now())
+		);
+
+		given(folderService.getBasicFolderList(userId)).willReturn(folderResultList);
+
+		// when
+		mockMvc.perform(get("/api/folders/basic")
+				   .header("Authorization", "test-token")
+				   .contentType(MediaType.APPLICATION_JSON))
+			   .andExpect(status().isOk());
+
+		// then
+		then(folderApiMapper).should(times(3)).toApiResponse(any());
+		then(folderService).should(times(1)).getBasicFolderList(userId);
+
+		folderApiMapper.toApiResponse(null);
+		folderApiMapper.toApiResponse(new FolderResult(rootId, "root", FolderType.ROOT, null, null, null, LocalDateTime.now(), LocalDateTime.now()));
+	}
+
+	@Test
+	@DisplayName("폴더 생성")
+	void create_folder() throws Exception {
+		// given
+		var request = new FolderApiRequest.Create("새 폴더", rootId);
+		var command = new FolderCommand.Create(userId, request.name(), request.parentFolderId());
+		var result = new FolderResult(folderId, command.name(), FolderType.GENERAL, command.parentFolderId(), new ArrayList<>(), new ArrayList<>(), LocalDateTime.now(), LocalDateTime.now());
+
+		given(folderService.saveFolder(command)).willReturn(result);
+
+		// when
+		mockMvc.perform(post("/api/folders")
+				   .content(objectMapper.writeValueAsString(request))
+				   .header("Authorization", "test-token")
+				   .contentType(MediaType.APPLICATION_JSON))
+			   .andExpect(status().isOk());
+
+		// then
+		then(folderApiMapper).should(times(1)).toCreateCommand(userId, request);
+		then(folderService).should(times(1)).saveFolder(command);
+		then(folderApiMapper).should(times(1)).toApiResponse(result);
+
+		folderApiMapper.toCreateCommand(null, null);
+		folderApiMapper.toCreateCommand(null, request);
+		folderApiMapper.toCreateCommand(userId, null);
+	}
+
+	@Test
+	@DisplayName("폴더 수정")
+	void update_folder() throws Exception {
+		// given
+		var request = new FolderApiRequest.Update(folderId, "변경");
+		var command = new FolderCommand.Update(userId, request.id(), request.name());
+
+		// when
+		mockMvc.perform(patch("/api/folders")
+				   .content(objectMapper.writeValueAsString(request))
+				   .header("Authorization", "test-token")
+				   .contentType(MediaType.APPLICATION_JSON))
+			   .andExpect(status().isNoContent());
+
+		// then
+		then(folderApiMapper).should(times(1)).toUpdateCommand(userId, request);
+		then(folderService).should(times(1)).updateFolder(command);
+
+		folderApiMapper.toUpdateCommand(null, null);
+		folderApiMapper.toUpdateCommand(null, request);
+		folderApiMapper.toUpdateCommand(userId, null);
+	}
+
+	@Test
+	@DisplayName("폴더 이동")
+	void move_folder() throws Exception {
+		// given
+		List<Long> folderIdList = List.of(folderId, otherFolderId);
+		var request = new FolderApiRequest.Move(folderIdList, rootId, rootId, 0);
+		var command = new FolderCommand.Move(userId, folderIdList, rootId, rootId, 0);
+
+		// when
+		mockMvc.perform(patch("/api/folders/location")
+				   .content(objectMapper.writeValueAsString(request))
+				   .header("Authorization", "test-token")
+				   .contentType(MediaType.APPLICATION_JSON))
+			   .andExpect(status().isNoContent());
+
+		// then
+		then(folderApiMapper).should(times(1)).toMoveCommand(userId, request);
+		then(folderService).should(times(1)).moveFolder(command);
+
+		folderApiMapper.toMoveCommand(null, null);
+		folderApiMapper.toMoveCommand(null, request);
+		folderApiMapper.toMoveCommand(userId, null);
+		folderApiMapper.toMoveCommand(userId, new FolderApiRequest.Move(null, rootId, rootId, 0));
+	}
+
+	@Test
+	@DisplayName("폴더 삭제")
+	void delete_folder() throws Exception {
+		// given
+		List<Long> folderIdList = List.of(folderId);
+		var request = new FolderApiRequest.Delete(folderIdList);
+		var command = new FolderCommand.Delete(userId, folderIdList);
+
+		// when
+		mockMvc.perform(delete("/api/folders")
+				   .content(objectMapper.writeValueAsString(request))
+				   .header("Authorization", "test-token")
+				   .contentType(MediaType.APPLICATION_JSON))
+			   .andExpect(status().isNoContent());
+
+		// then
+		then(folderApiMapper).should(times(1)).toDeleteCommand(userId, request);
+		then(folderService).should(times(1)).deleteFolder(command);
+
+		folderApiMapper.toDeleteCommand(null, null);
+		folderApiMapper.toDeleteCommand(null, request);
+		folderApiMapper.toDeleteCommand(userId, null);
+		folderApiMapper.toDeleteCommand(userId, new FolderApiRequest.Delete(null));
+	}
+}

--- a/backend/baguni-api/src/test/java/baguni/api/application/folder/controller/FolderApiControllerUnitTest.java
+++ b/backend/baguni-api/src/test/java/baguni/api/application/folder/controller/FolderApiControllerUnitTest.java
@@ -1,0 +1,183 @@
+package baguni.api.application.folder.controller;
+
+import static org.mockito.BDDMockito.*;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import baguni.api.application.folder.dto.FolderApiMapper;
+import baguni.api.application.folder.dto.FolderApiRequest;
+import baguni.api.application.folder.dto.FolderApiResponse;
+import baguni.api.service.folder.service.FolderService;
+import baguni.api.service.sharedFolder.service.SharedFolderService;
+import baguni.domain.infrastructure.folder.dto.FolderCommand;
+import baguni.domain.infrastructure.folder.dto.FolderResult;
+import baguni.domain.model.folder.FolderType;
+
+@DisplayName("폴더 컨트롤러 - 단위 테스트")
+@ExtendWith(MockitoExtension.class)
+class FolderApiControllerUnitTest {
+
+	@Mock
+	private FolderService folderService;
+
+	@Mock
+	private SharedFolderService sharedFolderService;
+
+	@Mock
+	private FolderApiMapper folderApiMapper;
+
+	@InjectMocks
+	private FolderApiController folderApiController;
+
+	Long userId, folderId, otherFolderId, rootId, unclassifiedId, recycleBinId, sharedFolderId;
+	String uuidToken;
+
+	@BeforeEach
+	void setUp() {
+		userId = 1L;
+		rootId = 1L; unclassifiedId = 2L; recycleBinId = 3L; folderId = 4L; otherFolderId = 5L;
+		sharedFolderId = 1L;
+		uuidToken = UUID.randomUUID().toString();
+	}
+
+	@Test
+	@DisplayName("루트 폴더와 하위 리스트 조회")
+	void all_root_folder() {
+		// given
+		List<FolderResult> folderResultList = List.of(
+			new FolderResult(rootId, "root", FolderType.ROOT, null, List.of(folderId, otherFolderId), new ArrayList<>(), LocalDateTime.now(), LocalDateTime.now()),
+			new FolderResult(folderId, "폴더1", FolderType.GENERAL, rootId, new ArrayList<>(), new ArrayList<>(), LocalDateTime.now(), LocalDateTime.now()),
+			new FolderResult(otherFolderId, "폴더2", FolderType.GENERAL, rootId, new ArrayList<>(), new ArrayList<>(), LocalDateTime.now(), LocalDateTime.now())
+		);
+
+		for (FolderResult folderResult : folderResultList) {
+			String folderAccessToken = UUID.randomUUID().toString();
+			Optional<String> optionalAccessToken = Optional.of(folderAccessToken);
+			given(sharedFolderService.findFolderAccessTokenByFolderId(folderResult.id())).willReturn(optionalAccessToken);
+			given(folderApiMapper.toApiResponse(folderResult, folderAccessToken)).willReturn(new FolderApiResponse(folderResult.id(), folderResult.name(), folderResult.folderType(), folderResult.parentFolderId(), folderResult.childFolderIdOrderedList(), folderResult.createdAt(), folderResult.updatedAt(), folderAccessToken));
+		}
+
+		given(folderService.getAllRootFolderList(userId)).willReturn(folderResultList);
+
+		// when
+		folderApiController.getAllRootFolderList(userId);
+
+		// then
+		then(sharedFolderService).should(times(3)).findFolderAccessTokenByFolderId(any());
+		then(folderService).should(times(1)).getAllRootFolderList(userId);
+		then(folderApiMapper).should(times(3)).toApiResponse(any(), any());
+	}
+
+	@Test
+	@DisplayName("기본 폴더 리스트 조회")
+	void basic_folder() {
+		// given
+		List<FolderResult> folderResultList = List.of(
+			new FolderResult(rootId, "root", FolderType.ROOT, null, new ArrayList<>(), new ArrayList<>(), LocalDateTime.now(), LocalDateTime.now()),
+			new FolderResult(unclassifiedId, "unclassified", FolderType.UNCLASSIFIED, null, new ArrayList<>(), new ArrayList<>(), LocalDateTime.now(), LocalDateTime.now()),
+			new FolderResult(recycleBinId, "recycleBin", FolderType.RECYCLE_BIN, null, new ArrayList<>(), new ArrayList<>(), LocalDateTime.now(), LocalDateTime.now())
+		);
+
+		for (FolderResult folderResult : folderResultList) {
+			String folderAccessToken = UUID.randomUUID().toString();
+			var response = new FolderApiResponse(folderResult.id(), folderResult.name(), folderResult.folderType(), folderResult.parentFolderId(), folderResult.childFolderIdOrderedList(), folderResult.createdAt(), folderResult.updatedAt(), folderAccessToken);
+			given(folderApiMapper.toApiResponse(folderResult)).willReturn(response);
+		}
+
+		given(folderService.getBasicFolderList(userId)).willReturn(folderResultList);
+
+		// when
+		folderApiController.getBasicFolderList(userId);
+
+		// then
+		then(folderApiMapper).should(times(3)).toApiResponse(any());
+		then(folderService).should(times(1)).getBasicFolderList(userId);
+	}
+
+	@Test
+	@DisplayName("폴더 생성")
+	void create_folder() {
+		// given
+		var request = new FolderApiRequest.Create("새 폴더", rootId);
+		var command = new FolderCommand.Create(userId, request.name(), request.parentFolderId());
+		var result = new FolderResult(folderId, command.name(), FolderType.GENERAL, command.parentFolderId(), new ArrayList<>(), new ArrayList<>(), LocalDateTime.now(), LocalDateTime.now());
+		var response = new FolderApiResponse(folderId, command.name(), FolderType.GENERAL, command.parentFolderId(), new ArrayList<>(), LocalDateTime.now(), LocalDateTime.now(), uuidToken);
+
+		given(folderApiMapper.toCreateCommand(userId, request)).willReturn(command);
+		given(folderService.saveFolder(command)).willReturn(result);
+		given(folderApiMapper.toApiResponse(result)).willReturn(response);
+
+		// when
+		folderApiController.createFolder(userId, request);
+
+		// then
+		then(folderApiMapper).should(times(1)).toCreateCommand(userId, request);
+		then(folderService).should(times(1)).saveFolder(command);
+		then(folderApiMapper).should(times(1)).toApiResponse(result);
+	}
+
+	@Test
+	@DisplayName("폴더 수정")
+	void update_folder() {
+		// given
+		var request = new FolderApiRequest.Update(folderId, "변경");
+		var command = new FolderCommand.Update(userId, request.id(), request.name());
+
+		given(folderApiMapper.toUpdateCommand(userId, request)).willReturn(command);
+
+		// when
+		folderApiController.updateFolder(userId, request);
+
+		// then
+		then(folderApiMapper).should(times(1)).toUpdateCommand(userId, request);
+		then(folderService).should(times(1)).updateFolder(command);
+	}
+
+	@Test
+	@DisplayName("폴더 이동")
+	void move_folder() {
+		// given
+		List<Long> folderIdList = List.of(folderId, otherFolderId);
+		var request = new FolderApiRequest.Move(folderIdList, rootId, rootId, 0);
+		var command = new FolderCommand.Move(userId, folderIdList, rootId, rootId, 0);
+
+		given(folderApiMapper.toMoveCommand(userId, request)).willReturn(command);
+
+		// when
+		folderApiController.moveFolder(userId, request);
+
+		// then
+		then(folderApiMapper).should(times(1)).toMoveCommand(userId, request);
+		then(folderService).should(times(1)).moveFolder(command);
+	}
+
+	@Test
+	@DisplayName("폴더 삭제")
+	void delete_folder() {
+		// given
+		List<Long> folderIdList = List.of(folderId);
+		var request = new FolderApiRequest.Delete(folderIdList);
+		var command = new FolderCommand.Delete(userId, folderIdList);
+
+		given(folderApiMapper.toDeleteCommand(userId, request)).willReturn(command);
+
+		// when
+		folderApiController.deleteFolder(userId, request);
+
+		// then
+		then(folderApiMapper).should(times(1)).toDeleteCommand(userId, request);
+		then(folderService).should(times(1)).deleteFolder(command);
+	}
+}

--- a/backend/baguni-api/src/test/java/baguni/api/application/pick/controller/PickApiControllerTest.java
+++ b/backend/baguni-api/src/test/java/baguni/api/application/pick/controller/PickApiControllerTest.java
@@ -1,0 +1,469 @@
+package baguni.api.application.pick.controller;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import baguni.BaguniApiApplication;
+import baguni.api.application.pick.dto.PickApiMapper;
+import baguni.api.application.pick.dto.PickApiMapperImpl;
+import baguni.api.application.pick.dto.PickApiRequest;
+import baguni.api.application.pick.dto.PickApiResponse;
+import baguni.api.service.pick.service.PickSearchService;
+import baguni.api.service.pick.service.PickService;
+import baguni.api.service.user.service.UserService;
+import baguni.common.event.events.BookmarkCreateEvent;
+import baguni.common.event.messenger.EventMessenger;
+import baguni.domain.infrastructure.link.dto.LinkInfo;
+import baguni.domain.infrastructure.pick.dto.PickCommand;
+import baguni.domain.infrastructure.pick.dto.PickResult;
+import baguni.domain.infrastructure.user.dto.UserInfo;
+import baguni.domain.model.util.IDToken;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * @Author sangwon
+ * @WebMvcTest 사용할 수 있었지만, 빈 주입해야 하는 부분이 너무 많아 @SpringBootTest 사용
+ * 실제 DB에 데이터가 들어가는 것은 시큐리티 때문에 까다로워서 컨트롤러 부분만 테스트하고자 함.
+ *
+ * 슬라이스 테스트 : 특정 레이어만 잘라서 테스트하는 기법
+ * 컨트롤러만 테스트하는 것
+ */
+@Slf4j
+@SpringBootTest(classes = BaguniApiApplication.class)
+@ActiveProfiles("local")
+@AutoConfigureMockMvc // MockMvc 사용을 위한 설정
+@Import(PickApiMapperImpl.class) // @SpyBean 구현체 인식을 못하여 추가
+@DisplayName("픽 컨트롤러 - 슬라이스 테스트")
+class PickApiControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@MockBean
+	private PickService pickService;
+
+	@SpyBean
+	private PickApiMapper pickApiMapper;
+
+	@MockBean
+	private UserService userService;
+
+	@MockBean
+	private PickSearchService pickSearchService;
+
+	@MockBean
+	private EventMessenger eventMessenger;
+
+	// 반드시 있어야 함.
+	@MockBean
+	private SecurityFilterChain securityFilterChain; // 실제 시큐리티 구현체 사용하지 않기 위함.
+
+	Long userId, pickId, otherPickId;
+	List<Long> folderIdList;
+	String folderIdListParam;
+	LinkInfo linkInfo, otherLinkInfo;
+	IDToken idToken;
+	UserInfo userInfo;
+
+	@BeforeEach
+	void setUp() {
+		userId = 1L;
+		pickId = 1L;
+		otherPickId = 2L;
+		folderIdList = List.of(1L, 2L, 3L);
+		folderIdListParam = listToString(folderIdList);
+		linkInfo = new LinkInfo("https://example.com", "linkTitle", "description", "imageUrl");
+		otherLinkInfo = new LinkInfo("https://other.example.com", "linkTitle", "description", "imageUrl");
+
+		idToken = IDToken.fromString(UUID.randomUUID().toString());
+		var authentication = new UsernamePasswordAuthenticationToken(idToken, null,
+			List.of(new SimpleGrantedAuthority("ROLE_USER")));
+
+		// @LoginUserId에서 사용하므로 임의의 데이터 세팅
+		SecurityContextHolder.getContext().setAuthentication(authentication);
+
+		userInfo = new UserInfo(userId, "user", idToken, "email@example.com");
+
+		// 반드시 있어야 합니다. userInfo 객체를 인식합니다.
+		given(userService.getUserInfoByToken(idToken)).willReturn(userInfo);
+	}
+
+	@AfterEach
+	void cleanUp() {
+		// 설정했던 시큐리티 데이터 제거
+		SecurityContextHolder.clearContext();
+	}
+
+	@Nested
+	@DisplayName("픽 조회")
+	class FindPickList {
+
+		@Test
+		@DisplayName("폴더 리스트 내 픽 리스트 조회")
+		void get_folder_child_pick_list() throws Exception {
+			// given
+			var readList = new PickCommand.ReadList(userId, folderIdList);
+			var folderPickList = List.of(
+				new PickResult.FolderPickWithViewCountList(folderIdList.get(0),
+					List.of(
+						new PickResult.PickWithViewCount(pickId, "픽1",
+							linkInfo,
+							folderIdList.get(0),
+							new ArrayList<>(),
+							LocalDateTime.now(),
+							LocalDateTime.now(),
+							false,
+							1L
+						),
+						new PickResult.PickWithViewCount(otherPickId, "픽2",
+							otherLinkInfo,
+							folderIdList.get(0),
+							new ArrayList<>(),
+							LocalDateTime.now(),
+							LocalDateTime.now(),
+							false,
+							1L
+						)
+					)),
+				new PickResult.FolderPickWithViewCountList(folderIdList.get(1), new ArrayList<>()),
+				new PickResult.FolderPickWithViewCountList(folderIdList.get(2), new ArrayList<>())
+			);
+			given(pickService.getFolderListChildPickList(readList)).willReturn(folderPickList);
+
+			// when
+			mockMvc.perform(get("/api/picks")
+					   .param("folderIdList", folderIdListParam)
+					   .header("Authorization", "test-token")
+					   .contentType(MediaType.APPLICATION_JSON))
+				   .andExpect(status().isOk());
+
+			// then
+			then(pickApiMapper).should(times(1)).toReadListCommand(userId, folderIdList);
+			then(pickApiMapper).should(times(3)).toApiFolderPickListWithViewCount(any());
+
+			pickApiMapper.toReadListCommand(null, null);
+			pickApiMapper.toReadListCommand(null, folderIdList);
+			pickApiMapper.toReadListCommand(userId, null);
+		}
+
+		@Test
+		@DisplayName("폴더 내 픽 리스트 조회 - folderPickList null")
+		void get_folder_child_pick_list_null() throws Exception {
+			// given
+			var readList = new PickCommand.ReadList(userId, null);
+
+			given(pickService.getFolderListChildPickList(readList)).willReturn(null);
+
+			// when
+			mockMvc.perform(get("/api/picks")
+					   .param("folderIdList", "") // 빈 배열 전달
+					   .header("Authorization", "test-token")
+					   .contentType(MediaType.APPLICATION_JSON))
+				   .andExpect(status().isOk());
+
+			// then
+			var result = pickApiMapper.toApiFolderPickListWithViewCount(null);
+			assertThat(result).isNull();
+			then(pickApiMapper).should(times(1)).toApiFolderPickListWithViewCount(any());
+		}
+
+		@Test
+		@DisplayName("링크 픽 여부 조회")
+		void exist_pick() throws Exception {
+			// given
+			given(pickService.existPickByUrl(userId, linkInfo.url())).willReturn(true);
+
+			// when
+			mockMvc.perform(get("/api/picks/link")
+					   .param("link", linkInfo.url()) // 빈 배열 전달
+					   .header("Authorization", "test-token")
+					   .contentType(MediaType.APPLICATION_JSON))
+				   .andExpect(status().isOk());
+
+			// then
+			then(pickService).should(times(1)).existPickByUrl(userId, linkInfo.url());
+			then(pickApiMapper).should(times(1)).toApiExistResponse(true);
+
+			pickApiMapper.toApiExistResponse(null);
+			pickApiMapper.toApiExistResponse(false);
+		}
+	}
+
+	@Nested
+	@DisplayName("픽 검색")
+	class PickSearch {
+
+		@Test
+		@DisplayName("픽 리스트 검색")
+		void search_pick_list() throws Exception {
+			// given
+			List<String> searchTokenList = List.of("pick1", "pick2");
+			List<Long> tagIdList = List.of(1L, 2L);
+			Long cursor = 0L;
+			int size = 20;
+
+			var command = new PickCommand.SearchPagination(userId, folderIdList, searchTokenList, tagIdList, cursor,
+				size);
+			var pickResultList = new SliceImpl<>(
+				List.of(
+					new PickResult.Pick(pickId, "pick1", linkInfo, folderIdList.get(0), tagIdList, LocalDateTime.now(),
+						LocalDateTime.now()),
+					new PickResult.Pick(otherPickId, "pick2", otherLinkInfo, folderIdList.get(1), tagIdList,
+						LocalDateTime.now(),
+						LocalDateTime.now()),
+					new PickResult.Pick(3L, "pick3", otherLinkInfo, folderIdList.get(2), tagIdList, LocalDateTime.now(),
+						LocalDateTime.now())
+				)
+			);
+
+			given(pickSearchService.searchPickPagination(command)).willReturn(pickResultList);
+
+			// when
+			mockMvc.perform(get("/api/picks/search")
+					   .param("folderIdList", folderIdListParam)
+					   .param("searchTokenList", listToString(searchTokenList))
+					   .param("tagIdList", listToString(tagIdList))
+					   .param("cursor", String.valueOf(cursor))
+					   .param("size", String.valueOf(size))
+					   .header("Authorization", "test-token")
+					   .contentType(MediaType.APPLICATION_JSON))
+				   .andExpect(status().isOk());
+
+			// then
+			then(pickApiMapper)
+				.should(times(1))
+				.toSearchPaginationCommand(userId, folderIdList, searchTokenList, tagIdList, cursor, size);
+			then(pickSearchService).should(times(1)).searchPickPagination(command);
+			then(pickApiMapper).should(times(1)).toSliceApiResponse(pickResultList);
+
+			// toSearchPaginationCommand 분기 테스트
+			pickApiMapper.toSearchPaginationCommand(null, null, null, null, null, null);
+			pickApiMapper.toSearchPaginationCommand(userId, null, searchTokenList, tagIdList, cursor, size);
+			pickApiMapper.toSearchPaginationCommand(userId, folderIdList, null, tagIdList, cursor, size);
+			pickApiMapper.toSearchPaginationCommand(userId, folderIdList, searchTokenList, null, cursor, size);
+			pickApiMapper.toSearchPaginationCommand(userId, folderIdList, searchTokenList, tagIdList, cursor, null);
+			pickApiMapper.toSearchPaginationCommand(null, folderIdList, searchTokenList, tagIdList, cursor, size);
+			pickApiMapper.toSearchPaginationCommand(null, null, searchTokenList, tagIdList, cursor, size);
+			pickApiMapper.toSearchPaginationCommand(null, null, null, tagIdList, cursor, size);
+			pickApiMapper.toSearchPaginationCommand(null, null, null, null, cursor, size);
+			pickApiMapper.toSearchPaginationCommand(null, null, null, null, null, size);
+		}
+	}
+
+	@Nested
+	@DisplayName("픽 생성, 수정, 이동, 삭제")
+	class Create {
+
+		@Test
+		@DisplayName("픽 생성 테스트")
+		void create_pick() throws Exception {
+			// given
+			var request = new PickApiRequest.Create("pick1", new ArrayList<>(), folderIdList.get(0), linkInfo);
+			var command = new PickCommand.Create(userId, "pick1", new ArrayList<>(), folderIdList.get(0), linkInfo);
+			var result = new PickResult.Pick(pickId, "pick1", linkInfo, folderIdList.get(0), new ArrayList<>(),
+				LocalDateTime.now(), LocalDateTime.now());
+
+			given(pickService.saveNewPick(command)).willReturn(result);
+
+			// when
+			mockMvc.perform(post("/api/picks")
+					   .content(objectMapper.writeValueAsString(request))
+					   .contentType(MediaType.APPLICATION_JSON))
+				   .andExpect(status().isOk());
+
+			// then
+			then(pickApiMapper).should(times(1)).toCreateCommand(userId, request);
+			then(pickService).should(times(1)).saveNewPick(command);
+			then(eventMessenger).should(times(1)).send(any(BookmarkCreateEvent.class));
+			then(pickApiMapper).should(times(1)).toApiResponse(result);
+
+			// toCreateCommand 분기 테스트
+			pickApiMapper.toCreateCommand(null, null);
+			pickApiMapper.toCreateCommand(userId, null);
+			pickApiMapper.toCreateCommand(null, request);
+			pickApiMapper.toCreateCommand(userId, new PickApiRequest.Create("pick1", null, folderIdList.get(0), linkInfo));
+		}
+
+		@Test
+		@DisplayName("픽 수정")
+		void update_pick() throws Exception {
+			// given
+			var request = new PickApiRequest.Update(pickId, "pick", new ArrayList<>());
+			var command = new PickCommand.Update(userId, pickId,"pick", null, new ArrayList<>()) ;
+			var result = new PickResult.Pick(pickId, "pick", linkInfo, null, new ArrayList<>(), LocalDateTime.now(), LocalDateTime.now());
+
+			given(pickService.updatePick(command)).willReturn(result);
+
+			// when
+			mockMvc.perform(patch("/api/picks")
+					   .content(objectMapper.writeValueAsString(request))
+					   .contentType(MediaType.APPLICATION_JSON))
+				   .andExpect(status().isOk());
+
+			// then
+			then(pickApiMapper).should(times(1)).toUpdateCommand(userId, request);
+			then(pickService).should(times(1)).updatePick(command);
+			then(pickApiMapper).should(times(1)).toApiResponse(result);
+
+			pickApiMapper.toApiResponse(null);
+			pickApiMapper.toApiResponse(new PickResult.Pick(pickId, "pick", linkInfo, null, null, LocalDateTime.now(), LocalDateTime.now()));
+			pickApiMapper.toUpdateCommand(null, (PickApiRequest.Update) null);
+			pickApiMapper.toUpdateCommand(null, request);
+			pickApiMapper.toUpdateCommand(userId, (PickApiRequest.Update) null);
+			pickApiMapper.toUpdateCommand(userId, new PickApiRequest.Update(pickId, "pick", null));
+		}
+
+		@Test
+		@DisplayName("픽 이동")
+		void move_pick() throws Exception {
+			// given
+			List<Long> idList = List.of(pickId);
+			var request = new PickApiRequest.Move(idList, folderIdList.get(0), 0);
+			var command = new PickCommand.Move(userId, idList, folderIdList.get(0), 0);
+
+			// when
+			mockMvc.perform(patch("/api/picks/location")
+					   .content(objectMapper.writeValueAsString(request))
+					   .contentType(MediaType.APPLICATION_JSON))
+				   .andExpect(status().isNoContent());
+
+			// then
+			then(pickApiMapper).should(times(1)).toMoveCommand(userId, request);
+			then(pickService).should(times(1)).movePick(command);
+
+			pickApiMapper.toMoveCommand(null,  null);
+			pickApiMapper.toMoveCommand(null,  request);
+			pickApiMapper.toMoveCommand(userId, null);
+			pickApiMapper.toMoveCommand(userId, new PickApiRequest.Move(null, folderIdList.get(0), 0));
+		}
+
+		@Test
+		@DisplayName("픽 삭제")
+		void delete_pick() throws Exception {
+			// given
+			List<Long> idList = List.of(pickId);
+			var request = new PickApiRequest.Delete(idList);
+			var command = new PickCommand.Delete(userId, idList);
+
+			// when
+			mockMvc.perform(delete("/api/picks")
+					   .content(objectMapper.writeValueAsString(request))
+					   .contentType(MediaType.APPLICATION_JSON))
+				   .andExpect(status().isNoContent());
+
+			// then
+			then(pickApiMapper).should(times(1)).toDeleteCommand(userId, request);
+			then(pickService).should(times(1)).deletePick(command);
+
+			pickApiMapper.toDeleteCommand(null,  null);
+			pickApiMapper.toDeleteCommand(null, request);
+			pickApiMapper.toDeleteCommand(userId, null);
+			pickApiMapper.toDeleteCommand(userId, new PickApiRequest.Delete(null));
+		}
+	}
+
+	@Nested
+	@DisplayName("익스텐션 관련")
+	class Extension {
+
+		@Test
+		@DisplayName("익스텐션 픽 생성")
+		void create_extension_pick() throws Exception {
+			// given
+			var request = new PickApiRequest.CreateFromExtension(linkInfo.url(), linkInfo.title());
+			var command = new PickCommand.Extension(userId, linkInfo.title(), linkInfo.url());
+			var result = new PickResult.Extension(pickId, "pick1", 1L, linkInfo.url(), folderIdList.get(0),
+				new ArrayList<>(), LocalDateTime.now(), LocalDateTime.now());
+
+			given(pickService.savePickToUnclassified(command)).willReturn(result);
+
+			// when
+			mockMvc.perform(post("/api/picks/extension")
+					   .content(objectMapper.writeValueAsString(request))
+					   .contentType(MediaType.APPLICATION_JSON))
+				   .andExpect(status().isOk());
+
+			// then
+			then(pickApiMapper).should(times(1)).toExtensionCommand(userId, linkInfo.title(), linkInfo.url());
+			then(pickService).should(times(1)).savePickToUnclassified(command);
+			then(eventMessenger).should(times(1)).send(any(BookmarkCreateEvent.class));
+			then(pickApiMapper).should(times(1)).toApiExtensionResponse(result);
+
+			pickApiMapper.toExtensionCommand(null, null, null);
+			pickApiMapper.toExtensionCommand(null, null, linkInfo.url());
+			pickApiMapper.toExtensionCommand(null, linkInfo.title(), null);
+			pickApiMapper.toExtensionCommand(null, linkInfo.title(), linkInfo.url());
+			pickApiMapper.toApiExtensionResponse(null);
+			pickApiMapper.toApiExtensionResponse(new PickResult.Extension(pickId, "pick1", 1L, linkInfo.url(), folderIdList.get(0),
+				null, LocalDateTime.now(), LocalDateTime.now()));
+		}
+
+		@Test
+		@DisplayName("익스텐션 픽 수정")
+		void update_extension_pick() throws Exception {
+			// given
+			var request = new PickApiRequest.UpdateFromExtension(pickId, "pick", folderIdList.get(0), List.of(1L, 2L)) ;
+			var command = new PickCommand.Update(userId, pickId,"pick", folderIdList.get(0), List.of(1L, 2L)) ;
+			var result = new PickResult.Pick(pickId, "pick", linkInfo, folderIdList.get(0), List.of(1L, 2L), LocalDateTime.now(), LocalDateTime.now());
+
+			given(pickService.updatePick(command)).willReturn(result);
+
+			// when
+			mockMvc.perform(patch("/api/picks/extension")
+					   .content(objectMapper.writeValueAsString(request))
+					   .contentType(MediaType.APPLICATION_JSON))
+				   .andExpect(status().isOk());
+
+			// then
+			then(pickApiMapper).should(times(1)).toUpdateCommand(userId, request);
+			then(pickService).should(times(1)).updatePick(command);
+			then(pickApiMapper).should(times(1)).toApiResponse(result);
+
+			pickApiMapper.toUpdateCommand(null, (PickApiRequest.UpdateFromExtension) null);
+			pickApiMapper.toUpdateCommand(userId, (PickApiRequest.UpdateFromExtension) null);
+			pickApiMapper.toUpdateCommand(null, request);
+			pickApiMapper.toUpdateCommand(userId, new PickApiRequest.UpdateFromExtension(pickId, "pick", null, null));
+		}
+	}
+
+	private String listToString(List<?> list) {
+		return String.join(",", list.stream().map(String::valueOf).toList());
+	}
+
+}

--- a/backend/baguni-api/src/test/java/baguni/api/application/pick/controller/PickApiControllerUnitTest.java
+++ b/backend/baguni-api/src/test/java/baguni/api/application/pick/controller/PickApiControllerUnitTest.java
@@ -1,0 +1,292 @@
+package baguni.api.application.pick.controller;
+
+import static org.mockito.BDDMockito.*;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.SliceImpl;
+
+import baguni.api.application.pick.dto.PickApiMapper;
+import baguni.api.application.pick.dto.PickApiRequest;
+import baguni.api.application.pick.dto.PickApiResponse;
+import baguni.api.service.pick.service.PickSearchService;
+import baguni.api.service.pick.service.PickService;
+import baguni.common.event.events.BookmarkCreateEvent;
+import baguni.common.event.messenger.EventMessenger;
+import baguni.domain.infrastructure.link.dto.LinkInfo;
+import baguni.domain.infrastructure.pick.dto.PickCommand;
+import baguni.domain.infrastructure.pick.dto.PickResult;
+
+/**
+ * 컨트롤러 단위 테스트는 해당 클래스 참고 부탁드립니다.
+ * given(), then() 사용하려면 BDDMockito.given() 사용해서 static import
+ */
+@DisplayName("픽 컨트롤러 - 단위 테스트")
+@ExtendWith(MockitoExtension.class)
+class PickApiControllerUnitTest {
+
+	@Mock
+	private PickService pickService;
+
+	@Mock
+	private PickApiMapper pickApiMapper;
+
+	@Mock
+	private PickSearchService pickSearchService;
+
+	@Mock
+	private EventMessenger eventMessenger;
+
+	@InjectMocks
+	private PickApiController pickApiController;
+
+	Long userId, pickId, otherPickId;
+	List<Long> folderIdList;
+	LinkInfo linkInfo, otherLinkInfo;
+
+	@BeforeEach
+	void setUp() {
+		userId = 1L;
+		pickId = 1L;
+		otherPickId = 2L;
+		folderIdList = List.of(1L, 2L);
+		linkInfo = new LinkInfo("https://example.com", "linkTitle", "description", "imageUrl");
+		otherLinkInfo = new LinkInfo("https://other.example.com", "linkTitle", "description", "imageUrl");
+	}
+
+	@Test
+	@DisplayName("폴더 리스트 내 픽 리스트 조회 테스트")
+	void get_folder_child_pick_list() {
+		// given
+		var readList = new PickCommand.ReadList(userId, folderIdList);
+		var folderPickList = List.of(
+			new PickResult.FolderPickWithViewCountList(folderIdList.get(0),
+				List.of(
+					new PickResult.PickWithViewCount(pickId, "픽1",
+						linkInfo,
+						folderIdList.get(0),
+						new ArrayList<>(),
+						LocalDateTime.now(),
+						LocalDateTime.now(),
+						false,
+						1L
+					),
+					new PickResult.PickWithViewCount(otherPickId, "픽2",
+						otherLinkInfo,
+						folderIdList.get(0),
+						new ArrayList<>(),
+						LocalDateTime.now(),
+						LocalDateTime.now(),
+						false,
+						1L
+					)
+				))
+		);
+
+		given(pickApiMapper.toReadListCommand(userId, folderIdList)).willReturn(readList);
+		given(pickService.getFolderListChildPickList(readList)).willReturn(folderPickList);
+
+		// when
+		pickApiController.getFolderChildPickList(userId, folderIdList);
+
+		// then
+		then(pickApiMapper).should(times(1)).toReadListCommand(userId, folderIdList);
+		then(pickService).should(times(1)).getFolderListChildPickList(readList);
+	}
+
+	@Test
+	@DisplayName("픽 리스트 검색")
+	void pick_search_test() {
+		// given
+		List<String> searchTokenList = List.of("리액트", "서버");
+		List<Long> tagIdList = List.of(1L, 2L);
+		Long cursor = 0L;
+		int size = 20;
+
+		var command = new PickCommand.SearchPagination(userId, folderIdList, searchTokenList, tagIdList, cursor, size);
+		var pickResultList = new SliceImpl<>(
+			List.of(
+				new PickResult.Pick(pickId, "pick1", linkInfo, folderIdList.get(0), tagIdList, LocalDateTime.now(),
+					LocalDateTime.now()),
+				new PickResult.Pick(otherPickId, "pick2", otherLinkInfo, folderIdList.get(0), tagIdList, LocalDateTime.now(),
+					LocalDateTime.now())
+			)
+		);
+		var slicePickApiResponse = new SliceImpl<>(
+			List.of(
+				new PickApiResponse.Pick(pickId, "pick1", linkInfo, folderIdList.get(0), tagIdList, LocalDateTime.now(),
+					LocalDateTime.now()),
+				new PickApiResponse.Pick(otherPickId, "pick2", otherLinkInfo, folderIdList.get(0), tagIdList,
+					LocalDateTime.now(),
+					LocalDateTime.now())
+			)
+		);
+
+		given(pickApiMapper.toSearchPaginationCommand(userId, folderIdList, searchTokenList, tagIdList, cursor, size))
+			.willReturn(command);
+		given(pickSearchService.searchPickPagination(command)).willReturn(pickResultList);
+		given(pickApiMapper.toSliceApiResponse(pickResultList)).willReturn(slicePickApiResponse);
+
+		// when
+		pickApiController.searchPickPagination(userId, folderIdList, searchTokenList, tagIdList, cursor, size);
+
+		// then
+		then(pickApiMapper).should(times(1)).toSearchPaginationCommand(userId, folderIdList, searchTokenList, tagIdList, cursor, size);
+		then(pickSearchService).should(times(1)).searchPickPagination(command);
+		then(pickApiMapper).should(times(1)).toSliceApiResponse(pickResultList);
+	}
+
+	@Test
+	@DisplayName("링크 픽 여부 조회")
+	void exist_pick_link_test() {
+		// given
+		String url = "https://example.com";
+		PickApiResponse.Exist exist = new PickApiResponse.Exist(true);
+
+		given(pickService.existPickByUrl(userId, url)).willReturn(true);
+		given(pickApiMapper.toApiExistResponse(true)).willReturn(exist);
+
+		// when
+		pickApiController.existPick(userId, url);
+
+		// then
+		then(pickService).should(times(1)).existPickByUrl(userId, url);
+		then(pickApiMapper).should(times(1)).toApiExistResponse(true);
+	}
+
+	@Test
+	@DisplayName("픽 생성")
+	void create_pick_test() {
+		// given
+		var request = new PickApiRequest.Create("pick1", new ArrayList<>(), folderIdList.get(0), linkInfo);
+		var command = new PickCommand.Create(userId, "pick1", new ArrayList<>(), folderIdList.get(0), linkInfo);
+		var result = new PickResult.Pick(pickId, "pick1", linkInfo, folderIdList.get(0), new ArrayList<>(), LocalDateTime.now(), LocalDateTime.now());
+		var response = new PickApiResponse.Pick(pickId, "pick1", linkInfo, folderIdList.get(0), new ArrayList<>(), LocalDateTime.now(), LocalDateTime.now());
+
+		given(pickApiMapper.toCreateCommand(userId, request)).willReturn(command);
+		given(pickService.saveNewPick(command)).willReturn(result);
+		given(pickApiMapper.toApiResponse(result)).willReturn(response);
+
+		// when
+		pickApiController.savePick(userId, request);
+
+		// then
+		then(pickApiMapper).should(times(1)).toCreateCommand(userId, request);
+		then(pickService).should(times(1)).saveNewPick(command);
+		then(eventMessenger).should(times(1)).send(any(BookmarkCreateEvent.class));
+		then(pickApiMapper).should(times(1)).toApiResponse(result);
+	}
+
+	@Test
+	@DisplayName("익스텐션 픽 생성")
+	void extension_save_test() {
+		// given
+		var request = new PickApiRequest.CreateFromExtension(linkInfo.url(), linkInfo.title());
+		var command = new PickCommand.Extension(userId, linkInfo.title(), linkInfo.url());
+		var result = new PickResult.Extension(pickId, "pick1", 1L, linkInfo.url(), folderIdList.get(0),
+			new ArrayList<>(), LocalDateTime.now(), LocalDateTime.now());
+		var response = new PickApiResponse.Extension(pickId, "pick1", folderIdList.get(0), new ArrayList<>(), LocalDateTime.now(), LocalDateTime.now());
+
+		given(pickApiMapper.toExtensionCommand(userId, linkInfo.title(), linkInfo.url())).willReturn(command);
+		given(pickService.savePickToUnclassified(command)).willReturn(result);
+		given(pickApiMapper.toApiExtensionResponse(result)).willReturn(response);
+
+		// when
+		pickApiController.savePickAsUnclassified(userId, request);
+
+		// then
+		then(pickApiMapper).should(times(1)).toExtensionCommand(userId, linkInfo.title(), linkInfo.url());
+		then(pickService).should(times(1)).savePickToUnclassified(command);
+		then(eventMessenger).should(times(1)).send(any(BookmarkCreateEvent.class));
+		then(pickApiMapper).should(times(1)).toApiExtensionResponse(result);
+	}
+
+	@Test
+	@DisplayName("익스텐션 픽 수정")
+	void extension_update_test() {
+		// given
+		var request = new PickApiRequest.UpdateFromExtension(pickId, "pick", folderIdList.get(0), List.of(1L, 2L)) ;
+		var command = new PickCommand.Update(userId, pickId,"pick", folderIdList.get(0), List.of(1L, 2L)) ;
+		var result = new PickResult.Pick(pickId, "pick", linkInfo, folderIdList.get(0), List.of(1L, 2L), LocalDateTime.now(), LocalDateTime.now());
+		var response = new PickApiResponse.Pick(pickId, "pick", linkInfo, folderIdList.get(0), List.of(1L, 2L), LocalDateTime.now(), LocalDateTime.now());
+
+		given(pickApiMapper.toUpdateCommand(userId, request)).willReturn(command);
+		given(pickService.updatePick(command)).willReturn(result);
+		given(pickApiMapper.toApiResponse(result)).willReturn(response);
+
+		// when
+		pickApiController.updatePickFromChromeExtension(userId, request);
+
+		// then
+		then(pickApiMapper).should(times(1)).toUpdateCommand(userId, request);
+		then(pickService).should(times(1)).updatePick(command);
+		then(pickApiMapper).should(times(1)).toApiResponse(result);
+	}
+
+	@Test
+	@DisplayName("픽 수정")
+	void pick_update_test() {
+		// given
+		var request = new PickApiRequest.Update(pickId, "pick", new ArrayList<>());
+		var command = new PickCommand.Update(userId, pickId,"pick", folderIdList.get(0), List.of(1L, 2L)) ;
+		var result = new PickResult.Pick(pickId, "pick", linkInfo, folderIdList.get(0), List.of(1L, 2L), LocalDateTime.now(), LocalDateTime.now());
+		var response = new PickApiResponse.Pick(pickId, "pick", linkInfo, folderIdList.get(0), List.of(1L, 2L), LocalDateTime.now(), LocalDateTime.now());
+
+		given(pickApiMapper.toUpdateCommand(userId, request)).willReturn(command);
+		given(pickService.updatePick(command)).willReturn(result);
+		given(pickApiMapper.toApiResponse(result)).willReturn(response);
+
+		// when
+		pickApiController.updatePick(userId, request);
+
+		// then
+		then(pickApiMapper).should(times(1)).toUpdateCommand(userId, request);
+		then(pickService).should(times(1)).updatePick(command);
+		then(pickApiMapper).should(times(1)).toApiResponse(result);
+	}
+
+	@Test
+	@DisplayName("픽 이동")
+	void move_pick_test() {
+		// given
+		List<Long> idList = List.of(pickId);
+		var request = new PickApiRequest.Move(idList, folderIdList.get(0), 0);
+		var command = new PickCommand.Move(userId, idList, folderIdList.get(0), 0);
+
+		given(pickApiMapper.toMoveCommand(userId, request)).willReturn(command);
+
+		// when
+		pickApiController.movePick(userId, request);
+
+		// then
+		then(pickApiMapper).should(times(1)).toMoveCommand(userId, request);
+		then(pickService).should(times(1)).movePick(command);
+	}
+
+	@Test
+	@DisplayName("픽 삭제")
+	void delete_pick_test() {
+		// given
+		List<Long> idList = List.of(pickId);
+		var request = new PickApiRequest.Delete(idList);
+		var command = new PickCommand.Delete(userId, idList);
+
+		given(pickApiMapper.toDeleteCommand(userId, request)).willReturn(command);
+
+		// when
+		pickApiController.deletePick(userId, request);
+
+		// then
+		then(pickApiMapper).should(times(1)).toDeleteCommand(userId, request);
+		then(pickService).should(times(1)).deletePick(command);
+	}
+}

--- a/backend/baguni-api/src/test/java/baguni/api/application/sharedFolder/controller/SharedFolderApiControllerTest.java
+++ b/backend/baguni-api/src/test/java/baguni/api/application/sharedFolder/controller/SharedFolderApiControllerTest.java
@@ -1,0 +1,219 @@
+package baguni.api.application.sharedFolder.controller;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import baguni.BaguniApiApplication;
+import baguni.api.application.folder.dto.FolderApiMapperImpl;
+import baguni.api.application.sharedFolder.dto.SharedFolderApiMapper;
+import baguni.api.application.sharedFolder.dto.SharedFolderApiMapperImpl;
+import baguni.api.application.sharedFolder.dto.SharedFolderApiResponse;
+import baguni.api.service.sharedFolder.service.SharedFolderService;
+import baguni.api.service.user.service.UserService;
+import baguni.domain.infrastructure.folder.dto.FolderResult;
+import baguni.domain.infrastructure.sharedFolder.dto.SharedFolderResult;
+import baguni.domain.infrastructure.user.dto.UserInfo;
+import baguni.domain.model.folder.FolderType;
+import baguni.domain.model.util.IDToken;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@SpringBootTest(classes = BaguniApiApplication.class)
+@ActiveProfiles("local")
+@AutoConfigureMockMvc // MockMvc 사용을 위한 설정
+@Import(SharedFolderApiMapperImpl.class) // @SpyBean 구현체 인식을 못하여 추가
+@DisplayName("공유 폴더 컨트롤러 - 슬라이스 테스트")
+class SharedFolderApiControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@MockBean
+	private SecurityFilterChain securityFilterChain; // 실제 시큐리티 구현체 사용하지 않기 위함.
+
+	@SpyBean
+	private SharedFolderApiMapper sharedFolderApiMapper;
+
+	@MockBean
+	private UserService userService;
+
+	@MockBean
+	private SharedFolderService sharedFolderService;
+
+	Long userId, folderId, otherFolderId, rootId;
+	UUID uuid;
+	String folderAccessToken;
+	IDToken idToken;
+	UserInfo userInfo;
+
+	@BeforeEach
+	void setUp() {
+		userId = 1L;
+		rootId = 1L;
+		folderId = 2L;
+		otherFolderId = 3L;
+		uuid = UUID.randomUUID();
+		folderAccessToken = UUID.randomUUID().toString();
+
+		idToken = IDToken.fromString(UUID.randomUUID().toString());
+		var authentication = new UsernamePasswordAuthenticationToken(idToken, null,
+			List.of(new SimpleGrantedAuthority("ROLE_USER")));
+
+		// @LoginUserId에서 사용하므로 임의의 데이터 세팅
+		SecurityContextHolder.getContext().setAuthentication(authentication);
+
+		userInfo = new UserInfo(userId, "user", idToken, "email@example.com");
+
+		// 반드시 있어야 합니다. userInfo 객체를 인식합니다.
+		given(userService.getUserInfoByToken(idToken)).willReturn(userInfo);
+	}
+
+	@AfterEach
+	void cleanUp() {
+		// 설정했던 시큐리티 데이터 제거
+		SecurityContextHolder.clearContext();
+	}
+
+	@Test
+	@DisplayName("공유 폴더 등록")
+	void create_shared_folder() throws Exception {
+		// given
+		var result = new SharedFolderResult.Create(folderAccessToken);
+
+		given(sharedFolderService.createSharedFolder(userId, folderId)).willReturn(result);
+
+		// when
+		mockMvc.perform(post("/api/shared")
+				   .content(objectMapper.writeValueAsString(folderId))
+				   .header("Authorization", "test-token")
+				   .contentType(MediaType.APPLICATION_JSON))
+			   .andExpect(status().isOk());
+
+		// then
+		then(sharedFolderService).should(times(1)).createSharedFolder(userId, folderId);
+		then(sharedFolderApiMapper).should(times(1)).toCreateResponse(result);
+
+		sharedFolderApiMapper.toCreateResponse(null);
+	}
+
+	@Test
+	@DisplayName("공유 폴더 리스트 조회")
+	void get_shared_folder_list() throws Exception {
+		// given
+		String otherAccessToken = UUID.randomUUID().toString();
+		var result = List.of(
+			new SharedFolderResult.Read(new FolderResult(folderId, "폴더1", FolderType.GENERAL, rootId, new ArrayList<>(), new ArrayList<>(), LocalDateTime.now(), LocalDateTime.now()), folderAccessToken),
+			new SharedFolderResult.Read(new FolderResult(otherFolderId, "폴더2", FolderType.GENERAL, rootId, new ArrayList<>(), new ArrayList<>(), LocalDateTime.now(), LocalDateTime.now()), otherAccessToken)
+		);
+
+		given(sharedFolderService.getSharedFolderListByUserId(userId)).willReturn(result);
+
+		// when
+		mockMvc.perform(get("/api/shared")
+				   .header("Authorization", "test-token")
+				   .contentType(MediaType.APPLICATION_JSON))
+			   .andExpect(status().isOk());
+
+		// then
+		then(sharedFolderService).should(times(1)).getSharedFolderListByUserId(userId);
+		then(sharedFolderApiMapper).should(times(1)).toReadResponseList(result);
+
+		sharedFolderApiMapper.toReadResponseList(null);
+	}
+
+
+	@Test
+	@DisplayName("공유 폴더 리스트 조회 - null 체크")
+	void get_shared_folder_list_null_test() throws Exception {
+		// given
+		var result = List.of(
+			new SharedFolderResult.Read(null, null),
+			new SharedFolderResult.Read(new FolderResult(1L, "폴더1", FolderType.GENERAL, rootId, new ArrayList<>(), new ArrayList<>(), LocalDateTime.now(), null), UUID.randomUUID().toString()),
+			new SharedFolderResult.Read(new FolderResult(2L, "폴더2", FolderType.GENERAL, rootId, new ArrayList<>(), new ArrayList<>(), null, LocalDateTime.now()), UUID.randomUUID().toString()),
+			new SharedFolderResult.Read(new FolderResult(3L, null, FolderType.GENERAL, rootId, new ArrayList<>(), new ArrayList<>(), LocalDateTime.now(), LocalDateTime.now()), UUID.randomUUID().toString()),
+			new SharedFolderResult.Read(new FolderResult(null, "폴더3", FolderType.GENERAL, rootId, new ArrayList<>(), new ArrayList<>(), LocalDateTime.now(), LocalDateTime.now()), UUID.randomUUID().toString()),
+			new SharedFolderResult.Read(new FolderResult(4L, "폴더4", FolderType.GENERAL, null, new ArrayList<>(), new ArrayList<>(), LocalDateTime.now(), LocalDateTime.now()), UUID.randomUUID().toString()),
+			new SharedFolderResult.Read(new FolderResult(5L, "폴더4", FolderType.GENERAL, rootId, new ArrayList<>(), new ArrayList<>(), LocalDateTime.now(), LocalDateTime.now()), UUID.randomUUID().toString())
+		);
+
+		given(sharedFolderService.getSharedFolderListByUserId(userId)).willReturn(result);
+
+		// when
+		mockMvc.perform(get("/api/shared")
+				   .header("Authorization", "test-token")
+				   .contentType(MediaType.APPLICATION_JSON))
+			   .andExpect(status().isOk());
+
+		// then
+		then(sharedFolderService).should(times(1)).getSharedFolderListByUserId(userId);
+		then(sharedFolderApiMapper).should(times(1)).toReadResponseList(result);
+	}
+
+	@Test
+	@DisplayName("공유 폴더 취소")
+	void delete_shared_folder() throws Exception {
+		// given
+
+		// when
+		mockMvc.perform(delete("/api/shared/{sourceFolderId}", folderId)
+				   .header("Authorization", "test-token")
+				   .contentType(MediaType.APPLICATION_JSON))
+			   .andExpect(status().isNoContent());
+
+		// then
+		then(sharedFolderService).should(times(1)).deleteSharedFolder(userId, folderId);
+	}
+
+	@Test
+	@DisplayName("공유 폴더 조회")
+	void get_shared_folder_by_id() throws Exception {
+		// given
+		var result = new SharedFolderResult.SharedFolderInfo("폴더", LocalDateTime.now(), LocalDateTime.now(), new ArrayList<>(), new ArrayList<>());
+
+		given(sharedFolderService.getSharedFolderInfo(uuid)).willReturn(result);
+
+		// when
+		mockMvc.perform(get("/api/shared/{uuid}", uuid)
+				   .header("Authorization", "test-token")
+				   .contentType(MediaType.APPLICATION_JSON))
+			   .andExpect(status().isOk());
+
+		// then
+		then(sharedFolderService).should(times(1)).getSharedFolderInfo(uuid);
+		then(sharedFolderApiMapper).should(times(1)).toReadFolderFullResponse(result);
+
+		sharedFolderApiMapper.toReadFolderFullResponse(null);
+		sharedFolderApiMapper.toReadFolderFullResponse(new SharedFolderResult.SharedFolderInfo("폴더", LocalDateTime.now(), LocalDateTime.now(), null, new ArrayList<>()));
+		sharedFolderApiMapper.toReadFolderFullResponse(new SharedFolderResult.SharedFolderInfo("폴더", LocalDateTime.now(), LocalDateTime.now(), new ArrayList<>(), null));
+	}
+}

--- a/backend/baguni-api/src/test/java/baguni/api/application/sharedFolder/controller/SharedFolderApiControllerUnitTest.java
+++ b/backend/baguni-api/src/test/java/baguni/api/application/sharedFolder/controller/SharedFolderApiControllerUnitTest.java
@@ -1,0 +1,125 @@
+package baguni.api.application.sharedFolder.controller;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import baguni.api.application.sharedFolder.dto.SharedFolderApiMapper;
+import baguni.api.application.sharedFolder.dto.SharedFolderApiResponse;
+import baguni.api.service.sharedFolder.service.SharedFolderService;
+import baguni.domain.infrastructure.folder.dto.FolderResult;
+import baguni.domain.infrastructure.sharedFolder.dto.SharedFolderResult;
+import baguni.domain.model.folder.FolderType;
+
+@DisplayName("공유 폴더 컨트롤러 - 단위 테스트")
+@ExtendWith(MockitoExtension.class)
+class SharedFolderApiControllerUnitTest {
+
+	@Mock
+	private SharedFolderService sharedFolderService;
+
+	@Mock
+	private SharedFolderApiMapper sharedFolderApiMapper;
+
+	@InjectMocks
+	private SharedFolderApiController sharedFolderApiController;
+
+	Long userId, folderId, otherFolderId, rootId;
+	UUID uuid;
+	String folderAccessToken;
+
+	@BeforeEach
+	void setUp() {
+		userId = 1L;
+		rootId = 1L;
+		folderId = 2L;
+		otherFolderId = 3L;
+		uuid = UUID.randomUUID();
+		folderAccessToken = UUID.randomUUID().toString();
+	}
+
+	@Test
+	@DisplayName("공유 폴더 등록")
+	void create_shared_folder() {
+		// given
+		var result = new SharedFolderResult.Create(folderAccessToken);
+		var response = new SharedFolderApiResponse.Create(folderAccessToken);
+
+		given(sharedFolderService.createSharedFolder(userId, folderId)).willReturn(result);
+		given(sharedFolderApiMapper.toCreateResponse(result)).willReturn(response);
+
+		// when
+		sharedFolderApiController.createSharedFolder(userId, folderId);
+
+		// then
+		then(sharedFolderService).should(times(1)).createSharedFolder(userId, folderId);
+		then(sharedFolderApiMapper).should(times(1)).toCreateResponse(result);
+	}
+
+	@Test
+	@DisplayName("공유 폴더 리스트 조회")
+	void get_shared_folder_list() {
+		// given
+		String otherAccessToken = UUID.randomUUID().toString();
+		var result = List.of(
+			new SharedFolderResult.Read(new FolderResult(folderId, "폴더1", FolderType.GENERAL, rootId, new ArrayList<>(), new ArrayList<>(), LocalDateTime.now(), LocalDateTime.now()), folderAccessToken),
+			new SharedFolderResult.Read(new FolderResult(otherFolderId, "폴더2", FolderType.GENERAL, rootId, new ArrayList<>(), new ArrayList<>(), LocalDateTime.now(), LocalDateTime.now()), otherAccessToken)
+		);
+		var response = List.of(
+			new SharedFolderApiResponse.ReadFolderPartial(folderId, "폴더1", LocalDateTime.now(), LocalDateTime.now(), folderAccessToken),
+			new SharedFolderApiResponse.ReadFolderPartial(otherFolderId, "폴더2", LocalDateTime.now(), LocalDateTime.now(), otherAccessToken)
+		);
+
+		given(sharedFolderService.getSharedFolderListByUserId(userId)).willReturn(result);
+		given(sharedFolderApiMapper.toReadResponseList(result)).willReturn(response);
+
+		// when
+		sharedFolderApiController.getUserSharedFolderList(userId);
+
+		// then
+		then(sharedFolderService).should(times(1)).getSharedFolderListByUserId(userId);
+		then(sharedFolderApiMapper).should(times(1)).toReadResponseList(result);
+	}
+
+	@Test
+	@DisplayName("공유 폴더 취소")
+	void delete_shared_folder() {
+		// given
+
+		// when
+		sharedFolderApiController.deleteSharedFolder(userId, folderId);
+
+		// then
+		then(sharedFolderService).should(times(1)).deleteSharedFolder(userId, folderId);
+	}
+
+	@Test
+	@DisplayName("공유 폴더 조회")
+	void get_shared_folder_by_id() {
+		// given
+		var result = new SharedFolderResult.SharedFolderInfo("폴더", LocalDateTime.now(), LocalDateTime.now(), new ArrayList<>(), new ArrayList<>());
+		var response = new SharedFolderApiResponse.ReadFolderFull(result.folderName(), result.createdAt(), result.updatedAt(), result.pickList(), result.tagList());
+
+		given(sharedFolderService.getSharedFolderInfo(uuid)).willReturn(result);
+		given(sharedFolderApiMapper.toReadFolderFullResponse(result)).willReturn(response);
+
+		// when
+		sharedFolderApiController.getSharedFolderWithFullInfo(uuid);
+
+		// then
+		then(sharedFolderService).should(times(1)).getSharedFolderInfo(uuid);
+		then(sharedFolderApiMapper).should(times(1)).toReadFolderFullResponse(result);
+	}
+}

--- a/backend/baguni-api/src/test/java/baguni/api/application/suggestion/controller/RankingApiControllerTest.java
+++ b/backend/baguni-api/src/test/java/baguni/api/application/suggestion/controller/RankingApiControllerTest.java
@@ -1,0 +1,191 @@
+package baguni.api.application.suggestion.controller;
+
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.BDDMockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import baguni.BaguniApiApplication;
+import baguni.api.application.suggestion.dto.RankingApiMapper;
+import baguni.api.application.suggestion.dto.RankingApiMapperImpl;
+import baguni.api.service.link.service.LinkService;
+import baguni.api.service.ranking.dto.RankingResult;
+import baguni.api.service.ranking.service.RankingService;
+import baguni.api.service.user.service.UserService;
+import baguni.common.dto.UrlWithCount;
+import baguni.domain.infrastructure.link.dto.LinkInfo;
+import baguni.domain.infrastructure.user.dto.UserInfo;
+import baguni.domain.model.util.IDToken;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@SpringBootTest(classes = BaguniApiApplication.class)
+@ActiveProfiles("local")
+@AutoConfigureMockMvc // MockMvc 사용을 위한 설정
+@Import(RankingApiMapperImpl.class) // @SpyBean 구현체 인식을 못하여 추가
+@DisplayName("랭킹 컨트롤러 - 슬라이스 테스트")
+class RankingApiControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@MockBean
+	private SecurityFilterChain securityFilterChain; // 실제 시큐리티 구현체 사용하지 않기 위함.
+
+	@MockBean
+	private UserService userService;
+
+	@SpyBean
+	private RankingApiMapper rankingApiMapper;
+
+	@MockBean
+	private LinkService linkService;
+
+	@MockBean
+	private RankingService rankingService;
+
+	Long userId;
+	IDToken idToken;
+	UserInfo userInfo;
+
+	@BeforeEach
+	void setUp() {
+		userId = 1L;
+		idToken = IDToken.fromString(UUID.randomUUID().toString());
+		var authentication = new UsernamePasswordAuthenticationToken(idToken, null,
+			List.of(new SimpleGrantedAuthority("ROLE_USER")));
+
+		// @LoginUserId에서 사용하므로 임의의 데이터 세팅
+		SecurityContextHolder.getContext().setAuthentication(authentication);
+
+		userInfo = new UserInfo(userId, "user", idToken, "email@example.com");
+
+		// 반드시 있어야 합니다. userInfo 객체를 인식합니다.
+		given(userService.getUserInfoByToken(idToken)).willReturn(userInfo);
+	}
+
+	@AfterEach
+	void cleanUp() {
+		// 설정했던 시큐리티 데이터 제거
+		SecurityContextHolder.clearContext();
+	}
+
+	@Test
+	@DisplayName("인기 픽 랭킹 조회")
+	void get_ranking() throws Exception {
+		// given
+		List<UrlWithCount> dailyViewRanking = List.of(
+			new UrlWithCount("http://example.com/1", 100L),
+			new UrlWithCount("http://example.com/2", 90L)
+		);
+
+		List<UrlWithCount> past7DaysViewRanking = List.of(
+			new UrlWithCount("http://example.com/3", 300L),
+			new UrlWithCount("http://example.com/4", 250L)
+		);
+
+		List<UrlWithCount> past30DaysPickRanking = List.of(
+			new UrlWithCount("http://example.com/5", 50L),
+			new UrlWithCount("http://example.com/6", 45L)
+		);
+
+		var result = new RankingResult(
+			dailyViewRanking, past7DaysViewRanking, past30DaysPickRanking
+		);
+
+		given(rankingService.getUrlRanking(10)).willReturn(result);
+
+		for (UrlWithCount urlWithCount : dailyViewRanking) {
+			given(linkService.getLinkInfo(urlWithCount.url()))
+				.willReturn(new LinkInfo(urlWithCount.url(), "Title - " + urlWithCount.url(), "desc", "image.jpg"));
+		}
+		for (UrlWithCount urlWithCount : past7DaysViewRanking) {
+			given(linkService.getLinkInfo(urlWithCount.url()))
+				.willReturn(new LinkInfo(urlWithCount.url(), "Title - " + urlWithCount.url(), "desc", "image.jpg"));
+		}
+		for (UrlWithCount urlWithCount : past30DaysPickRanking) {
+			given(linkService.getLinkInfo(urlWithCount.url()))
+				.willReturn(new LinkInfo(urlWithCount.url(), "Title - " + urlWithCount.url(), "desc", "image.jpg"));
+		}
+
+		// when
+		mockMvc.perform(get("/api/suggestion/ranking")
+				   .header("Authorization", "test-token")
+				   .contentType(MediaType.APPLICATION_JSON))
+			   .andExpect(status().isOk());
+
+		// then
+		then(rankingService).should().getUrlRanking(10);
+
+		rankingApiMapper.toRankingWithLinkInfo(null, null);
+		rankingApiMapper.toRankingWithLinkInfo(new UrlWithCount("http://example.com/5", 50L), null);
+		rankingApiMapper.toRankingWithLinkInfo(null, new LinkInfo("", "Title", "desc", "image.jpg"));
+	}
+
+	@Test
+	@DisplayName("인기 픽 랭킹 조회 - 예외 테스트")
+	void get_ranking_exception() throws Exception {
+		// given
+		List<UrlWithCount> dailyViewRanking = List.of(
+			new UrlWithCount("http://example.com/1", 100L),
+			new UrlWithCount("http://example.com/2", 90L)
+		);
+
+		List<UrlWithCount> past30DaysPickRanking = List.of(
+			new UrlWithCount("http://example.com/5", 50L),
+			new UrlWithCount("http://example.com/6", 45L)
+		);
+
+		var result = new RankingResult(
+			dailyViewRanking, null, past30DaysPickRanking
+		);
+
+		given(rankingService.getUrlRanking(10)).willReturn(result);
+
+		for (UrlWithCount urlWithCount : dailyViewRanking) {
+			given(linkService.getLinkInfo(urlWithCount.url()))
+				.willReturn(new LinkInfo(urlWithCount.url(), "", "desc", "image.jpg"));
+		}
+
+		for (UrlWithCount urlWithCount : past30DaysPickRanking) {
+			given(linkService.getLinkInfo(urlWithCount.url()))
+				.willReturn(new LinkInfo(urlWithCount.url(), "Title - " + urlWithCount.url(), "desc", "image.jpg"));
+		}
+
+		// when
+		mockMvc.perform(get("/api/suggestion/ranking")
+				   .header("Authorization", "test-token")
+				   .contentType(MediaType.APPLICATION_JSON))
+			   .andExpect(status().isOk());
+
+		// then
+		then(rankingService).should().getUrlRanking(10);
+	}
+
+}

--- a/backend/baguni-api/src/test/java/baguni/api/application/tag/controller/TagApiControllerTest.java
+++ b/backend/baguni-api/src/test/java/baguni/api/application/tag/controller/TagApiControllerTest.java
@@ -1,0 +1,217 @@
+package baguni.api.application.tag.controller;
+
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import baguni.BaguniApiApplication;
+import baguni.api.application.tag.dto.TagApiMapper;
+import baguni.api.application.tag.dto.TagApiMapperImpl;
+import baguni.api.application.tag.dto.TagApiRequest;
+import baguni.api.service.tag.service.TagService;
+import baguni.api.service.user.service.UserService;
+import baguni.domain.infrastructure.tag.dto.TagCommand;
+import baguni.domain.infrastructure.tag.dto.TagResult;
+import baguni.domain.infrastructure.user.dto.UserInfo;
+import baguni.domain.model.util.IDToken;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@SpringBootTest(classes = BaguniApiApplication.class)
+@ActiveProfiles("local")
+@AutoConfigureMockMvc // MockMvc 사용을 위한 설정
+@Import(TagApiMapperImpl.class) // @SpyBean 구현체 인식을 못하여 추가
+@DisplayName("태그 컨트롤러 - 슬라이스 테스트")
+class TagApiControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@MockBean
+	private SecurityFilterChain securityFilterChain; // 실제 시큐리티 구현체 사용하지 않기 위함.
+
+	@SpyBean
+	private TagApiMapper tagApiMapper;
+
+	@MockBean
+	private TagService tagService;
+
+	@MockBean
+	private UserService userService;
+
+	Long userId, tagId, otherTagId;
+	IDToken idToken;
+	UserInfo userInfo;
+
+	@BeforeEach
+	void setUp() {
+		userId = 1L;
+		tagId = 1L;
+		otherTagId = 2L;
+
+		idToken = IDToken.fromString(UUID.randomUUID().toString());
+		var authentication = new UsernamePasswordAuthenticationToken(idToken, null,
+			List.of(new SimpleGrantedAuthority("ROLE_USER")));
+
+		// @LoginUserId에서 사용하므로 임의의 데이터 세팅
+		SecurityContextHolder.getContext().setAuthentication(authentication);
+
+		userInfo = new UserInfo(userId, "user", idToken, "email@example.com");
+
+		// 반드시 있어야 합니다. userInfo 객체를 인식합니다.
+		given(userService.getUserInfoByToken(idToken)).willReturn(userInfo);
+	}
+
+	@AfterEach
+	void cleanUp() {
+		// 설정했던 시큐리티 데이터 제거
+		SecurityContextHolder.clearContext();
+	}
+
+	@Test
+	@DisplayName("사용자 태그 조회")
+	void get_tag() throws Exception {
+		// given
+		var result = List.of(
+			new TagResult(tagId, "태그1", 0, userId),
+			new TagResult(otherTagId, "태그2", 0, userId)
+		);
+
+		given(tagService.getUserTagList(userId)).willReturn(result);
+
+		// when
+		mockMvc.perform(get("/api/tags")
+				   .header("Authorization", "test-token")
+				   .contentType(MediaType.APPLICATION_JSON))
+			   .andExpect(status().isOk());
+
+		// then
+		then(tagService).should(times(1)).getUserTagList(userId);
+		then(tagApiMapper).should(times(result.size())).toReadResponse(any());
+
+		tagApiMapper.toReadResponse(null);
+	}
+
+	@Test
+	@DisplayName("태그 추가")
+	void create_tag() throws Exception {
+		// given
+		var request = new TagApiRequest.Create("태그", 0);
+		var command = new TagCommand.Create(userId, request.name(), request.colorNumber());
+		var result = new TagResult(tagId, command.name(), command.colorNumber(), userId);
+
+		given(tagService.saveTag(command)).willReturn(result);
+
+		// when
+		mockMvc.perform(post("/api/tags")
+				   .content(objectMapper.writeValueAsString(request))
+				   .header("Authorization", "test-token")
+				   .contentType(MediaType.APPLICATION_JSON))
+			   .andExpect(status().isOk());
+
+		// then
+		then(tagApiMapper).should(times(1)).toCreateCommand(userId, request);
+		then(tagService).should(times(1)).saveTag(command);
+		then(tagApiMapper).should(times(1)).toCreateResponse(result);
+
+		tagApiMapper.toCreateCommand(null, null);
+		tagApiMapper.toCreateCommand(userId, null);
+		tagApiMapper.toCreateCommand(null, request);
+		tagApiMapper.toCreateResponse(null);
+	}
+
+	@Test
+	@DisplayName("태그 수정")
+	void update_tag() throws Exception {
+		// given
+		var request = new TagApiRequest.Update(tagId, "태그 수정", 1);
+		var command = new TagCommand.Update(userId, request.id(), request.name(), request.colorNumber());
+
+		// when
+		mockMvc.perform(patch("/api/tags")
+				   .content(objectMapper.writeValueAsString(request))
+				   .header("Authorization", "test-token")
+				   .contentType(MediaType.APPLICATION_JSON))
+			   .andExpect(status().isNoContent());
+
+		// then
+		then(tagApiMapper).should(times(1)).toUpdateCommand(userId, request);
+		then(tagService).should(times(1)).updateTag(command);
+
+		tagApiMapper.toUpdateCommand(null, null);
+		tagApiMapper.toUpdateCommand(userId, null);
+		tagApiMapper.toUpdateCommand(null, request);
+	}
+
+	@Test
+	@DisplayName("태그 이동")
+	void move_tag() throws Exception {
+		// given
+		var request = new TagApiRequest.Move(tagId, 0);
+		var command = new TagCommand.Move(userId, request.id(), request.orderIdx());
+
+		// when
+		mockMvc.perform(patch("/api/tags/location")
+				   .content(objectMapper.writeValueAsString(request))
+				   .header("Authorization", "test-token")
+				   .contentType(MediaType.APPLICATION_JSON))
+			   .andExpect(status().isNoContent());
+
+		// then
+		then(tagApiMapper).should(times(1)).toMoveCommand(userId, request);
+		then(tagService).should(times(1)).moveUserTag(command);
+
+		tagApiMapper.toMoveCommand(null, null);
+		tagApiMapper.toMoveCommand(userId, null);
+		tagApiMapper.toMoveCommand(null, request);
+	}
+
+	@Test
+	@DisplayName("태그 삭제")
+	void delete_tag() throws Exception {
+		// given
+		var request = new TagApiRequest.Delete(tagId);
+		var command = new TagCommand.Delete(userId, request.id());
+
+		// when
+		mockMvc.perform(delete("/api/tags")
+				   .content(objectMapper.writeValueAsString(request))
+				   .header("Authorization", "test-token")
+				   .contentType(MediaType.APPLICATION_JSON))
+			   .andExpect(status().isNoContent());
+
+		// then
+		then(tagApiMapper).should(times(1)).toDeleteCommand(userId, request);
+		then(tagService).should(times(1)).deleteTag(command);
+
+		tagApiMapper.toDeleteCommand(null, null);
+		tagApiMapper.toDeleteCommand(userId, null);
+		tagApiMapper.toDeleteCommand(null, request);
+	}
+}

--- a/backend/baguni-api/src/test/java/baguni/api/application/tag/controller/TagApiControllerUnitTest.java
+++ b/backend/baguni-api/src/test/java/baguni/api/application/tag/controller/TagApiControllerUnitTest.java
@@ -1,0 +1,165 @@
+package baguni.api.application.tag.controller;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import baguni.api.application.tag.dto.TagApiMapper;
+import baguni.api.application.tag.dto.TagApiRequest;
+import baguni.api.application.tag.dto.TagApiResponse;
+import baguni.api.service.tag.service.TagService;
+import baguni.domain.exception.tag.ApiTagException;
+import baguni.domain.infrastructure.tag.dto.TagCommand;
+import baguni.domain.infrastructure.tag.dto.TagResult;
+
+@DisplayName("태그 컨트롤러 - 단위 테스트")
+@ExtendWith(MockitoExtension.class)
+class TagApiControllerUnitTest {
+
+	@Mock
+	private TagService tagService;
+
+	@Mock
+	private TagApiMapper tagApiMapper;
+
+	@InjectMocks
+	private TagApiController tagApiController;
+
+	Long userId, tagId, otherTagId;
+
+	@BeforeEach
+	void setUp() {
+		userId = 1L;
+		tagId = 1L;
+		otherTagId = 2L;
+	}
+
+	@Test
+	@DisplayName("사용자 태그 조회")
+	void get_tag() {
+		// given
+		var result = List.of(
+			new TagResult(tagId, "태그1", 0, userId),
+			new TagResult(otherTagId, "태그2", 0, userId)
+		);
+
+		given(tagService.getUserTagList(userId)).willReturn(result);
+		for (TagResult tagResult : result) {
+			var response = new TagApiResponse.Read(tagResult.id(), tagResult.name(), tagResult.colorNumber());
+			given(tagApiMapper.toReadResponse(tagResult)).willReturn(response);
+		}
+
+		// when
+		tagApiController.getAllUserTag(userId);
+
+		// then
+		then(tagService).should(times(1)).getUserTagList(userId);
+		then(tagApiMapper).should(times(result.size())).toReadResponse(any());
+	}
+
+	@Test
+	@DisplayName("태그 추가")
+	void create_tag() {
+		// given
+		var request = new TagApiRequest.Create("태그", 0);
+		var command = new TagCommand.Create(userId, request.name(), request.colorNumber());
+		var result = new TagResult(tagId, command.name(), command.colorNumber(), userId);
+		var response = new TagApiResponse.Create(result.id(), result.name(), result.colorNumber());
+
+		given(tagApiMapper.toCreateCommand(userId, request)).willReturn(command);
+		given(tagService.saveTag(command)).willReturn(result);
+		given(tagApiMapper.toCreateResponse(result)).willReturn(response);
+
+		// when
+		tagApiController.createTag(userId, request);
+
+		// then
+		then(tagApiMapper).should(times(1)).toCreateCommand(userId, request);
+		then(tagService).should(times(1)).saveTag(command);
+		then(tagApiMapper).should(times(1)).toCreateResponse(result);
+	}
+
+	@Test
+	@DisplayName("태그 추가 - 200자 이상")
+	void create_tag_length() {
+		// given
+		var request = new TagApiRequest.Create("Test".repeat(51), 0);
+
+		// when, then
+		assertThatThrownBy(() -> tagApiController.createTag(userId, request))
+			.isInstanceOf(ApiTagException.class)
+			.hasMessageStartingWith(ApiTagException.TAG_NAME_TOO_LONG().getMessage());
+	}
+
+	@Test
+	@DisplayName("태그 수정")
+	void update_tag() {
+		// given
+		var request = new TagApiRequest.Update(tagId, "태그 수정", 1);
+		var command = new TagCommand.Update(userId, request.id(), request.name(), request.colorNumber());
+
+		given(tagApiMapper.toUpdateCommand(userId, request)).willReturn(command);
+
+		// when
+		tagApiController.updateTag(userId, request);
+
+		// then
+		then(tagApiMapper).should(times(1)).toUpdateCommand(userId, request);
+		then(tagService).should(times(1)).updateTag(command);
+	}
+
+	@Test
+	@DisplayName("태그 수정 - 200자 이상")
+	void update_tag_length() {
+		// given
+		var request = new TagApiRequest.Update(tagId, "Test".repeat(51), 1);
+
+		// when, then
+		assertThatThrownBy(() -> tagApiController.updateTag(userId, request))
+			.isInstanceOf(ApiTagException.class)
+			.hasMessageStartingWith(ApiTagException.TAG_NAME_TOO_LONG().getMessage());
+	}
+
+	@Test
+	@DisplayName("태그 이동")
+	void move_tag() {
+		// given
+		var request = new TagApiRequest.Move(tagId, 0);
+		var command = new TagCommand.Move(userId, request.id(), request.orderIdx());
+
+		given(tagApiMapper.toMoveCommand(userId, request)).willReturn(command);
+
+		// when
+		tagApiController.moveTag(userId, request);
+
+		// then
+		then(tagApiMapper).should(times(1)).toMoveCommand(userId, request);
+		then(tagService).should(times(1)).moveUserTag(command);
+	}
+
+	@Test
+	@DisplayName("태그 삭제")
+	void delete_tag() {
+		// given
+		var request = new TagApiRequest.Delete(tagId);
+		var command = new TagCommand.Delete(userId, request.id());
+
+		given(tagApiMapper.toDeleteCommand(userId, request)).willReturn(command);
+
+		// when
+		tagApiController.deleteTag(userId, request);
+
+		// then
+		then(tagApiMapper).should(times(1)).toDeleteCommand(userId, request);
+		then(tagService).should(times(1)).deleteTag(command);
+	}
+}

--- a/backend/baguni-api/src/test/java/baguni/api/application/user/controller/UserApiControllerTest.java
+++ b/backend/baguni-api/src/test/java/baguni/api/application/user/controller/UserApiControllerTest.java
@@ -1,0 +1,127 @@
+package baguni.api.application.user.controller;
+
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import baguni.BaguniApiApplication;
+import baguni.api.application.user.controller.dto.UserApiMapper;
+import baguni.api.application.user.controller.dto.UserApiMapperImpl;
+import baguni.api.service.user.service.UserService;
+import baguni.domain.infrastructure.user.dto.UserInfo;
+import baguni.domain.model.util.IDToken;
+import baguni.security.util.CookieUtil;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@SpringBootTest(classes = BaguniApiApplication.class)
+@ActiveProfiles("local")
+@AutoConfigureMockMvc // MockMvc 사용을 위한 설정
+@Import(UserApiMapperImpl.class) // @SpyBean 구현체 인식을 못하여 추가
+@DisplayName("유저 컨트롤러 - 슬라이스 테스트")
+class UserApiControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@MockBean
+	private SecurityFilterChain securityFilterChain; // 실제 시큐리티 구현체 사용하지 않기 위함.
+
+	@MockBean
+	private UserService userService;
+
+	@SpyBean
+	private UserApiMapper userApiMapper;
+
+	@MockBean
+	private CookieUtil cookieUtil;
+
+	Long userId;
+	IDToken idToken;
+	UserInfo userInfo;
+
+	@BeforeEach
+	void setUp() {
+		userId = 1L;
+
+		idToken = IDToken.fromString(UUID.randomUUID().toString());
+		var authentication = new UsernamePasswordAuthenticationToken(idToken, null,
+			List.of(new SimpleGrantedAuthority("ROLE_USER")));
+
+		// @LoginUserId에서 사용하므로 임의의 데이터 세팅
+		SecurityContextHolder.getContext().setAuthentication(authentication);
+
+		userInfo = new UserInfo(userId, "user", idToken, "email@example.com");
+
+		// 반드시 있어야 합니다. userInfo 객체를 인식합니다.
+		given(userService.getUserInfoByToken(idToken)).willReturn(userInfo);
+	}
+
+	@AfterEach
+	void cleanUp() {
+		// 설정했던 시큐리티 데이터 제거
+		SecurityContextHolder.clearContext();
+	}
+
+	@Test
+	@DisplayName("회원 탈퇴")
+	void delete_user() throws Exception {
+		// given
+
+		// when
+		mockMvc.perform(delete("/api/users")
+				   .header("Authorization", "test-token")
+				   .contentType(MediaType.APPLICATION_JSON))
+			   .andExpect(status().isNoContent());
+
+		// then
+		then(userService).should(times(1)).deleteUser(userId);
+		then(cookieUtil).should(times(1)).clearCookies(any());
+	}
+
+	@Test
+	@DisplayName("유저 정보 조회")
+	void get_user() throws Exception {
+		// given
+		given(userService.getUserInfoById(userId)).willReturn(userInfo);
+
+		// when
+		mockMvc.perform(get("/api/users")
+				   .header("Authorization", "test-token")
+				   .contentType(MediaType.APPLICATION_JSON))
+			   .andExpect(status().isOk());
+
+		// then
+		then(userService).should(times(1)).getUserInfoById(userId);
+		then(userApiMapper).should(times(1)).toApiResponse(userInfo);
+
+		userApiMapper.toApiResponse(null);
+	}
+}

--- a/backend/baguni-api/src/test/java/baguni/api/service/pick/service/PickServiceTest.java
+++ b/backend/baguni-api/src/test/java/baguni/api/service/pick/service/PickServiceTest.java
@@ -5,27 +5,18 @@ import static org.mockito.Mockito.*;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 
-import baguni.api.application.suggestion.dto.RankingResponse;
-import baguni.api.service.pick.service.PickService;
 import baguni.api.service.ranking.dto.RankingResult;
 import baguni.api.service.ranking.service.RankingService;
 import baguni.common.dto.UrlWithCount;
@@ -336,7 +327,7 @@ class PickServiceTest {
 		void findPickUrl_test() {
 			// given
 			LinkInfo linkInfo = new LinkInfo("findPickUrl", "linkTitle", "linkDescription", "imageUrl");
-			PickCommand.Unclassified command = new PickCommand.Unclassified(user.getId(), linkInfo.title(),
+			PickCommand.Extension command = new PickCommand.Extension(user.getId(), linkInfo.title(),
 				linkInfo.url());
 
 			// when

--- a/backend/baguni-domain/src/main/java/baguni/domain/infrastructure/pick/PickDataHandler.java
+++ b/backend/baguni-domain/src/main/java/baguni/domain/infrastructure/pick/PickDataHandler.java
@@ -117,7 +117,7 @@ public class PickDataHandler {
 	 * 픽 생성 시 Link 데이터 수정하지 않음.
 	 */
 	@Transactional
-	public Pick savePickToUnclassified(PickCommand.Unclassified command) {
+	public Pick savePickToUnclassified(PickCommand.Extension command) {
 		User user = userRepository.findById(command.userId()).orElseThrow(ApiUserException::USER_NOT_FOUND);
 		Folder unclassified = folderRepository.findUnclassifiedByUserId(user.getId());
 		Link link = linkRepository.findByUrl(command.url())

--- a/backend/baguni-domain/src/main/java/baguni/domain/infrastructure/pick/dto/PickCommand.java
+++ b/backend/baguni-domain/src/main/java/baguni/domain/infrastructure/pick/dto/PickCommand.java
@@ -20,7 +20,7 @@ public class PickCommand {
 						 LinkInfo linkInfo) {
 	}
 
-	public record Unclassified(Long userId, String title, String url) {
+	public record Extension(Long userId, String title, String url) {
 	}
 
 	public record Update(Long userId, Long id, String title, Long parentFolderId, List<Long> tagIdOrderedList) {


### PR DESCRIPTION
- Close #892

## What is this PR? 🔍

- 기능 : 컨트롤러 테스트 구현
- issue : #892

## Changes 📝
- API 모듈의 라인 커버리지 74%, 분기 커버리지 65% 달성
- 링크 API, 이벤트 API 제외하고 모든 API 테스트 완료
- 다음 작업을 위해 테스트 코드 작성은 멈추고 리팩토링이 진행될 때 수정하는 방향으로 가면 좋을 것 같습니다.
<img width="771" alt="image" src="https://github.com/user-attachments/assets/6ac4a16c-006e-4083-bbd4-5ec670d1352a" />

- API 폴더만 보면, 라인 커버리지 92%, 분기 커버리지 94% 입니다.

## 기타 사항
- Batch 모듈, Ranking 모듈 테스트 코드 작성 필요