### PR TITLE
[FEAT] 익스텐션 픽 저장 API, 휴지통 비우기 API

### DIFF
--- a/backend/baguni-api/src/main/java/baguni/api/application/extension/controller/ExtensionApiControllerV1.java
+++ b/backend/baguni-api/src/main/java/baguni/api/application/extension/controller/ExtensionApiControllerV1.java
@@ -1,0 +1,67 @@
+package baguni.api.application.extension.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import baguni.api.application.extension.dto.ExtensionApiMapper;
+import baguni.api.application.extension.dto.ExtensionApiRequest;
+import baguni.api.application.extension.dto.ExtensionApiResponse;
+import baguni.api.service.pick.service.PickService;
+import baguni.common.event.events.BookmarkCreateEvent;
+import baguni.common.event.messenger.EventMessenger;
+import baguni.security.annotation.LoginUserId;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/extension/v1")
+@Tag(name = "익스텐션 API", description = "익스텐션 API는 메이저 버전을 명시합니다.")
+public class ExtensionApiControllerV1 {
+
+	private final PickService pickService;
+	private final ExtensionApiMapper extensionApiMapper;
+	private final EventMessenger eventMessenger;
+
+	@PostMapping("/picks")
+	@Operation(
+		summary = "[익스텐션 v1] 픽 생성",
+		description = """
+			익스텐션에서 픽 생성합니다.
+			익스텐션 메이저 버전을 명시합니다. (ex. /v1, /v2, /v3)
+			또한, 픽 생성 이벤트가 랭킹 서버에 집계됩니다.
+		"""
+	)
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "픽 생성 성공"),
+		@ApiResponse(responseCode = "400", description = "유저 또는 폴더가 존재하지 않습니다."),
+		@ApiResponse(responseCode = "401", description = "잘못된 접근 (폴더, 태그)"),
+		@ApiResponse(responseCode = "406", description = "허용되지 않는 폴더")
+	})
+	public ResponseEntity<ExtensionApiResponse.Pick> savePickFromExtension(
+		@LoginUserId Long userId,
+		@Valid @RequestBody ExtensionApiRequest.Create request
+	) {
+		var command = extensionApiMapper.toPickCreateCommand(userId, request);
+		var result = pickService.savePickFromExtension(command);
+		var response = extensionApiMapper.toApiPickResponse(result);
+		eventMessenger.send(new BookmarkCreateEvent(request.url()));
+		return ResponseEntity.ok(response);
+	}
+
+	/**
+	 * 	익스텐션 전용 API가 필요한가? (내 폴더 리스트 조회, 태그 리스트 조회, 존재하는 픽)
+	 * 	프론트에게 질문 후 반영
+	 *
+	 * 	픽 수정은 기획에 따라 생성 여부가 달라짐
+	 */
+}

--- a/backend/baguni-api/src/main/java/baguni/api/application/extension/dto/ExtensionApiMapper.java
+++ b/backend/baguni-api/src/main/java/baguni/api/application/extension/dto/ExtensionApiMapper.java
@@ -1,0 +1,20 @@
+package baguni.api.application.extension.dto;
+
+import org.mapstruct.InjectionStrategy;
+import org.mapstruct.Mapper;
+import org.mapstruct.ReportingPolicy;
+
+import baguni.domain.infrastructure.pick.dto.PickCommand;
+import baguni.domain.infrastructure.pick.dto.PickResult;
+
+@Mapper(
+	componentModel = "spring",
+	injectionStrategy = InjectionStrategy.CONSTRUCTOR,
+	unmappedTargetPolicy = ReportingPolicy.ERROR
+)
+public interface ExtensionApiMapper {
+
+	PickCommand.CreateFromExtension toPickCreateCommand(Long userId, ExtensionApiRequest.Create request);
+
+	ExtensionApiResponse.Pick toApiPickResponse(PickResult.Extension result);
+}

--- a/backend/baguni-api/src/main/java/baguni/api/application/extension/dto/ExtensionApiRequest.java
+++ b/backend/baguni-api/src/main/java/baguni/api/application/extension/dto/ExtensionApiRequest.java
@@ -1,0 +1,18 @@
+package baguni.api.application.extension.dto;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+
+public class ExtensionApiRequest {
+
+	public record Create(
+		@Schema(example = "GitHub Actions를 이용한 코드 리뷰 문화 개선기") @NotEmpty String title,
+		@Schema(example = "[4, 5, 2, 1, 3]") List<Long> tagIdOrderedList,
+		@Schema(example = "1") @NotNull Long parentFolderId,
+		@Schema(example = "https://d2.naver.com/helloworld/8149881") @NotNull String url,
+		@Schema(example = "GitHub Actions를 이용한 코드 리뷰 문화 개선기") @NotEmpty String linkTitle
+	){}
+}

--- a/backend/baguni-api/src/main/java/baguni/api/application/extension/dto/ExtensionApiResponse.java
+++ b/backend/baguni-api/src/main/java/baguni/api/application/extension/dto/ExtensionApiResponse.java
@@ -1,0 +1,18 @@
+package baguni.api.application.extension.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class ExtensionApiResponse {
+
+	public record Pick(
+		Long id,
+		String title,
+		Long parentFolderId,
+		List<Long> tagIdOrderedList,
+		String url,
+		LocalDateTime createdAt,
+		LocalDateTime updatedAt
+	){
+	}
+}

--- a/backend/baguni-api/src/main/java/baguni/api/application/pick/controller/PickApiController.java
+++ b/backend/baguni-api/src/main/java/baguni/api/application/pick/controller/PickApiController.java
@@ -109,7 +109,7 @@ public class PickApiController {
 	}
 
 	@PostMapping
-	@Operation(summary = "픽 생성", description = "픽을 생성합니다. 또한, 픽 생성 이벤트가 랭킹 서버에 집계 됩니다.")
+	@Operation(summary = "웹 페이지에서 픽 생성", description = "웹 페이지에서 픽을 생성합니다. 또한, 픽 생성 이벤트가 랭킹 서버에 집계 됩니다.")
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "픽 생성 성공"),
 		@ApiResponse(responseCode = "401", description = "잘못된 태그 접근"),
@@ -128,6 +128,9 @@ public class PickApiController {
 		return ResponseEntity.ok(response);
 	}
 
+	/**
+	 *	익스텐션에서 사용하지 않게 되면 제거
+	 */
 	@MeasureTime
 	@PostMapping("/extension")
 	@Operation(

--- a/backend/baguni-api/src/main/java/baguni/api/application/pick/controller/PickApiController.java
+++ b/backend/baguni-api/src/main/java/baguni/api/application/pick/controller/PickApiController.java
@@ -7,7 +7,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -109,7 +108,7 @@ public class PickApiController {
 	}
 
 	@PostMapping
-	@Operation(summary = "웹 페이지에서 픽 생성", description = "웹 페이지에서 픽을 생성합니다. 또한, 픽 생성 이벤트가 랭킹 서버에 집계 됩니다.")
+	@Operation(summary = "웹 사이트에서 픽 생성", description = "웹 사이트에서 픽을 생성합니다. 또한, 픽 생성 이벤트가 랭킹 서버에 집계 됩니다.")
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "픽 생성 성공"),
 		@ApiResponse(responseCode = "401", description = "잘못된 태그 접근"),
@@ -171,7 +170,7 @@ public class PickApiController {
 	}
 
 	@PatchMapping
-	@Operation(summary = "웹사이트에서 픽 내용만 수정 (폴더 이동 X)", description = "픽 내용 수정 및 폴더 이동까지 지원합니다.")
+	@Operation(summary = "웹 사이트에서 픽 내용만 수정 (폴더 이동 X)", description = "픽 내용 수정 및 폴더 이동까지 지원합니다.")
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "픽 내용 수정 성공")
 	})
@@ -213,6 +212,18 @@ public class PickApiController {
 	) {
 		var command = pickApiMapper.toDeleteCommand(userId, request);
 		pickService.deletePick(command);
+		return ResponseEntity.noContent().build();
+	}
+
+	@DeleteMapping("/recycle-bin")
+	@Operation(summary = "휴지통 비우기", description = "휴지통에 있는 픽 리스트들을 모두 삭제합니다.")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "204", description = "픽 삭제 성공"),
+		@ApiResponse(responseCode = "406", description = "휴지통이 아닌 폴더에서 픽 삭제 불가"),
+		@ApiResponse(responseCode = "500", description = "미확인 서버 에러 혹은 존재하지 않는 픽 삭제")
+	})
+	public ResponseEntity<Void> deleteAllPickFromRecycleBin(@LoginUserId Long userId) {
+		pickService.deletePickFromRecycleBin(userId);
 		return ResponseEntity.noContent().build();
 	}
 }

--- a/backend/baguni-api/src/main/java/baguni/api/service/pick/service/PickService.java
+++ b/backend/baguni-api/src/main/java/baguni/api/service/pick/service/PickService.java
@@ -95,6 +95,18 @@ public class PickService {
 
 	@LoginUserIdDistributedLock
 	@Transactional
+	public PickResult.Extension savePickFromExtension(PickCommand.CreateFromExtension command) {
+		assertParentFolderIsNotRoot(command.parentFolderId());
+		assertUserIsFolderOwner(command.userId(), command.parentFolderId());
+		assertUserIsTagOwner(command.userId(), command.tagIdOrderedList());
+		return pickMapper.toExtensionResult(pickDataHandler.savePickFromExtension(command));
+	}
+
+	/**
+	 * 익스텐션에서 사용하지 않게 되는 경우, 제거 예정
+	 */
+	@LoginUserIdDistributedLock
+	@Transactional
 	public PickResult.Extension savePickToUnclassified(PickCommand.Extension command) {
 		return pickMapper.toExtensionResult(pickDataHandler.savePickToUnclassified(command));
 	}

--- a/backend/baguni-api/src/main/java/baguni/api/service/pick/service/PickService.java
+++ b/backend/baguni-api/src/main/java/baguni/api/service/pick/service/PickService.java
@@ -155,6 +155,12 @@ public class PickService {
 		pickDataHandler.deletePickList(command);
 	}
 
+	@LoginUserIdDistributedLock
+	@Transactional
+	public void deletePickFromRecycleBin(Long userId) {
+		pickDataHandler.deletePickFromRecycleBin(userId);
+	}
+
 	/**
 	 * Internal Helper Functions
 	 **/

--- a/backend/baguni-domain/src/main/java/baguni/domain/infrastructure/pick/PickDataHandler.java
+++ b/backend/baguni-domain/src/main/java/baguni/domain/infrastructure/pick/PickDataHandler.java
@@ -240,6 +240,18 @@ public class PickDataHandler {
 	}
 
 	@Transactional
+	public void deletePickFromRecycleBin(Long userId) {
+		Folder recycleBin = folderRepository.findRecycleBinByUserId(userId);
+		List<Long> pickIdList = recycleBin.getChildPickIdOrderedList();
+
+		pickIdList.forEach(pickId -> {
+			pickTagRepository.deleteByPickId(pickId);
+			pickRepository.deleteById(pickId);
+		});
+		pickIdList.clear();
+	}
+
+	@Transactional
 	public void attachTagToPickTag(Pick pick, Long tagId) {
 		Tag tag = tagRepository.findById(tagId)
 							   .orElseThrow(ApiTagException::TAG_NOT_FOUND);

--- a/backend/baguni-domain/src/main/java/baguni/domain/infrastructure/pick/PickTagRepository.java
+++ b/backend/baguni-domain/src/main/java/baguni/domain/infrastructure/pick/PickTagRepository.java
@@ -20,9 +20,9 @@ public interface PickTagRepository extends JpaRepository<PickTag, Long> {
 
 	void deleteByPick(Pick pick);
 
-	void deleteByTagId(Long tagId);
+	void deleteByPickId(Long pickId);
 
-	void deleteByPickAndTagId(Pick pick, Long tagId);
+	void deleteByTagId(Long tagId);
 
 	@Modifying
 	@Query("DELETE FROM PickTag pt WHERE pt.pick.id IN :pickIdList")

--- a/backend/baguni-domain/src/main/java/baguni/domain/infrastructure/pick/dto/PickCommand.java
+++ b/backend/baguni-domain/src/main/java/baguni/domain/infrastructure/pick/dto/PickCommand.java
@@ -20,6 +20,9 @@ public class PickCommand {
 						 LinkInfo linkInfo) {
 	}
 
+	public record CreateFromExtension(Long userId, String title, List<Long> tagIdOrderedList, Long parentFolderId, String url, String linkTitle) {
+	}
+
 	public record Extension(Long userId, String title, String url) {
 	}
 

--- a/backend/baguni-domain/src/main/java/baguni/domain/infrastructure/pick/dto/PickMapper.java
+++ b/backend/baguni-domain/src/main/java/baguni/domain/infrastructure/pick/dto/PickMapper.java
@@ -41,7 +41,13 @@ public interface PickMapper {
 	@Mapping(source = "user", target = "user")
 	Pick toEntity(PickCommand.Create command, User user, Folder parentFolder, Link link);
 
+	@Mapping(source = "command.title", target = "title")
+	@Mapping(source = "command.tagIdOrderedList", target = "tagIdOrderedList")
+	@Mapping(source = "parentFolder", target = "parentFolder")
+	@Mapping(source = "user", target = "user")
+	Pick toEntity(PickCommand.CreateFromExtension command, User user, Folder parentFolder, Link link);
+
 	@Mapping(source = "parentFolder", target = "parentFolder")
 	@Mapping(source = "link", target = "link")
-	Pick toEntityByExtension(String title, List<Long> tagIdOrderedList, User user, Folder parentFolder, Link link);
+	Pick toEntity(String title, List<Long> tagIdOrderedList, User user, Folder parentFolder, Link link);
 }


### PR DESCRIPTION
## What is this PR? 🔍

- 기능 : 익스텐션 픽 저장 API, 휴지통 비우기 API
- issue : #1000, #999

## Changes 📝
- 픽 저장 시 태그 설정, 폴더 설정이 가능하도록 하였습니다.
- 익스텐션 전용 컨트롤러, Mapper, DTO를 분리하였습니다. (픽 저장만)
- 휴지통 API 구현
- 현재 미분류로 픽 저장하는 부분은 모든 유저가 버전 업 되어 사용하지 않을 때 삭제하겠습니다.

## Question
1. 익스텐션에서는 저장만 가능하게 하고, 수정 폼은 보여주지 않을 계획인가요? 
(저는 중복 저장을 하려면 저장 폼만 보여줘야 한다고 생각합니다. + 누르면 익스텐션이 닫히기 때문)
2. 익스텐션 전용 API가 저장 외에 다른 API가 필요할까요?
(내 폴더 리스트 조회, 태그 리스트 조회, 존재하는 픽 조회)
익스텐션에서 리스트 조회하는 부분이 수정되거나 필요한 API가 있을 때 추가하는 방향은 어떨까요?