### PR TITLE
[FEAT] 모바일 뷰 폴더 리스트, 픽 페이지네이션 API

### DIFF
--- a/backend/baguni-api/src/main/java/baguni/api/application/mobile/controller/MobileApiController.java
+++ b/backend/baguni-api/src/main/java/baguni/api/application/mobile/controller/MobileApiController.java
@@ -70,7 +70,13 @@ public class MobileApiController {
 	public ResponseEntity<PickSliceResponse<PickApiResponse.Pick>> getFolderChildPickPagination(
 		@LoginUserId Long userId,
 		@Parameter(description = "조회할 폴더 ID", example = "1") @RequestParam Long folderId,
-		@Parameter(description = "픽 시작 id 조회", example = "0") @RequestParam(required = false, defaultValue = "0") Long cursor,
+		@Parameter(description = """
+				다음에 조회할 커서(cursor) 값입니다.
+				처음 페이지를 조회할 때는 0을 넣어주세요.
+				이후에는 응답으로 받은 lastCursor 값을 그대로 사용하시면 됩니다.
+				예시: lastCursor = 1 → 다음 요청에 cursor=1을 넣으면, 1은 제외하고 2부터 조회합니다.
+			""",
+			example = "0") @RequestParam(required = false, defaultValue = "0") Long cursor,
 		@Parameter(description = "한 페이지에 가져올 픽 개수", example = "20") @RequestParam(required = false, defaultValue = "20") int size
 	) {
 		var command = pickApiMapper.toReadPaginationCommand(userId, folderId, cursor, size);

--- a/backend/baguni-api/src/main/java/baguni/api/application/mobile/controller/MobileApiController.java
+++ b/backend/baguni-api/src/main/java/baguni/api/application/mobile/controller/MobileApiController.java
@@ -1,0 +1,87 @@
+package baguni.api.application.mobile.controller;
+
+import java.util.List;
+
+import org.springframework.data.domain.Slice;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import baguni.api.application.folder.dto.FolderApiMapper;
+import baguni.api.application.folder.dto.FolderApiResponse;
+import baguni.api.application.pick.dto.PickApiMapper;
+import baguni.api.application.pick.dto.PickApiResponse;
+import baguni.api.application.pick.dto.PickSliceResponse;
+import baguni.api.service.folder.service.FolderService;
+import baguni.api.service.pick.service.PickService;
+import baguni.api.service.sharedFolder.service.SharedFolderService;
+import baguni.domain.infrastructure.folder.dto.FolderResult;
+import baguni.domain.infrastructure.pick.dto.PickResult;
+import baguni.security.annotation.LoginUserId;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/mobile")
+@Tag(name = "모바일 API", description = "모바일 전용 API")
+public class MobileApiController {
+
+	private final PickService pickService;
+	private final PickApiMapper pickApiMapper;
+	private final FolderService folderService;
+	private final SharedFolderService sharedFolderService;
+	private final FolderApiMapper folderApiMapper;
+
+	@GetMapping("/folders")
+	@Operation(summary = "미분류, 휴지통 폴더와 루트 하위 폴더 조회",
+		description = """
+				폴더 depth가 1인 경우만 조회합니다.
+				사용자의 미분류, 휴지통 폴더와 루트 하위 전체 폴더를 조회합니다.
+				루트 폴더는 조회하지 않습니다.
+			""")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "조회 성공"),
+		@ApiResponse(responseCode = "401", description = "본인 폴더만 조회할 수 있습니다.")
+	})
+	public ResponseEntity<List<FolderApiResponse>> getMobileFolderList(@LoginUserId Long userId) {
+		return ResponseEntity.ok(
+			folderService.getMobileFolderList(userId).stream()
+						 .map(this::toApiResponseWithFolderAccessToken)
+						 .toList()
+		);
+	}
+
+	@GetMapping("/picks")
+	@Operation(summary = "폴더 내 픽 페이지네이션 리스트 조회",
+		description = """
+				해당 폴더의 픽 리스트를 조회합니다.
+				커서 기반 페이지네이션 처리된 리스트가 반환됩니다.
+			""")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "픽 리스트 조회 성공")
+	})
+	public ResponseEntity<PickSliceResponse<PickApiResponse.Pick>> getFolderChildPickPagination(
+		@LoginUserId Long userId,
+		@Parameter(description = "조회할 폴더 ID", example = "1") @RequestParam Long folderId,
+		@Parameter(description = "픽 시작 id 조회", example = "0") @RequestParam(required = false, defaultValue = "0") Long cursor,
+		@Parameter(description = "한 페이지에 가져올 픽 개수", example = "20") @RequestParam(required = false, defaultValue = "20") int size
+	) {
+		var command = pickApiMapper.toReadPaginationCommand(userId, folderId, cursor, size);
+		var pickList = pickService.getFolderListChildPickPagination(command);
+		return ResponseEntity.ok(pickApiMapper.toSliceApiResponse(pickList));
+	}
+
+	private FolderApiResponse toApiResponseWithFolderAccessToken(FolderResult folder) {
+		String folderAccessToken = sharedFolderService
+			.findFolderAccessTokenByFolderId(folder.id())
+			.orElse(null);
+		return folderApiMapper.toApiResponse(folder, folderAccessToken);
+	}
+}

--- a/backend/baguni-api/src/main/java/baguni/api/application/pick/controller/PickApiController.java
+++ b/backend/baguni-api/src/main/java/baguni/api/application/pick/controller/PickApiController.java
@@ -78,7 +78,13 @@ public class PickApiController {
 			"") List<String> searchTokenList,
 		@Parameter(description = "검색 태그 ID 목록", example = "1, 2, 3") @RequestParam(required = false,
 			defaultValue = "") List<Long> tagIdList,
-		@Parameter(description = "픽 시작 id 조회", example = "0") @RequestParam(required = false, defaultValue = "0") Long cursor,
+		@Parameter(description = """
+				다음에 조회할 커서(cursor) 값입니다.
+				처음 페이지를 조회할 때는 0을 넣어주세요.
+				이후에는 응답으로 받은 lastCursor 값을 그대로 사용하시면 됩니다.
+				예시: lastCursor = 1 → 다음 요청에 cursor=1을 넣으면, 1은 제외하고 2부터 조회합니다.
+			""",
+			example = "0") @RequestParam(required = false, defaultValue = "0") Long cursor,
 		@Parameter(description = "한 페이지에 가져올 픽 개수", example = "20") @RequestParam(required = false, defaultValue = "20"
 		) int size
 	) {

--- a/backend/baguni-api/src/main/java/baguni/api/application/pick/controller/PickApiController.java
+++ b/backend/baguni-api/src/main/java/baguni/api/application/pick/controller/PickApiController.java
@@ -87,8 +87,7 @@ public class PickApiController {
 		);
 
 		Slice<PickResult.Pick> pickResultList = pickSearchService.searchPickPagination(command);
-
-		return ResponseEntity.ok(new PickSliceResponse<>(pickApiMapper.toSliceApiResponse(pickResultList)));
+		return ResponseEntity.ok(pickApiMapper.toSliceApiResponse(pickResultList));
 	}
 
 	@GetMapping("/link")

--- a/backend/baguni-api/src/main/java/baguni/api/application/pick/dto/PickApiMapper.java
+++ b/backend/baguni-api/src/main/java/baguni/api/application/pick/dto/PickApiMapper.java
@@ -22,6 +22,8 @@ public interface PickApiMapper {
 
 	PickCommand.ReadList toReadListCommand(Long userId, List<Long> folderIdList);
 
+	PickCommand.ReadPagination toReadPaginationCommand(Long userId, Long folderId, Long cursor, Integer size);
+
 	PickCommand.SearchPagination toSearchPaginationCommand(Long userId, List<Long> folderIdList,
 		List<String> searchTokenList, List<Long> tagIdList, Long cursor, Integer size);
 
@@ -65,10 +67,13 @@ public interface PickApiMapper {
 					   .toList();
 	}
 
-	default Slice<PickApiResponse.Pick> toSliceApiResponse(Slice<PickResult.Pick> source) {
+	default PickSliceResponse<PickApiResponse.Pick> toSliceApiResponse(Slice<PickResult.Pick> source) {
 		List<PickApiResponse.Pick> convertedContent = source.getContent().stream()
 															.map(this::toApiResponse)
 															.toList();
-		return new SliceImpl<>(convertedContent, source.getPageable(), source.hasNext());
+		SliceImpl<PickApiResponse.Pick> pickSlice = new SliceImpl<>(convertedContent, source.getPageable(),
+			source.hasNext());
+
+		return new PickSliceResponse<>(pickSlice);
 	}
 }

--- a/backend/baguni-api/src/main/java/baguni/api/service/folder/service/FolderService.java
+++ b/backend/baguni-api/src/main/java/baguni/api/service/folder/service/FolderService.java
@@ -62,6 +62,23 @@ public class FolderService {
 						   .toList();
 	}
 
+	@Transactional(readOnly = true)
+	public List<FolderResult> getMobileFolderList(Long userId) {
+		List<FolderResult> folderList = new ArrayList<>(
+			List.of(
+				folderMapper.toResult(folderDataHandler.getUnclassifiedFolder(userId)),
+				folderMapper.toResult(folderDataHandler.getRecycleBin(userId))
+			)
+		);
+
+		Folder rootFolder = folderDataHandler.getRootFolder(userId);
+		rootFolder.getChildFolderIdOrderedList().stream()
+				  .map(folderDataHandler::getFolder)
+				  .map(folderMapper::toResult)
+				  .forEach(folderList::add);
+		return folderList;
+	}
+
 	/**
 	 * 생성하려는 폴더가 미분류폴더, 휴지통이 아닌지 검증합니다.
 	 * */

--- a/backend/baguni-api/src/main/java/baguni/api/service/pick/service/PickService.java
+++ b/backend/baguni-api/src/main/java/baguni/api/service/pick/service/PickService.java
@@ -8,9 +8,11 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.ObjectUtils;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import baguni.domain.infrastructure.pick.PickQuery;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import baguni.domain.annotation.LoginUserIdDistributedLock;
@@ -38,6 +40,7 @@ public class PickService {
 
 	private final TagDataHandler tagDataHandler;
 	private final PickDataHandler pickDataHandler;
+	private final PickQuery pickQuery;
 	private final PickMapper pickMapper;
 	private final FolderDataHandler folderDataHandler;
 	private final RankingService rankingService;
@@ -82,6 +85,13 @@ public class PickService {
 					  .peek(folderId -> assertUserIsFolderOwner(command.userId(), folderId))  // 폴더 접근 유효성 검사
 					  .map(this::getFolderChildPickResultList)
 					  .toList();
+	}
+
+	@Transactional(readOnly = true)
+	public Slice<PickResult.Pick> getFolderListChildPickPagination(PickCommand.ReadPagination command) {
+		assertUserIsFolderOwner(command.userId(), command.folderId());
+		return pickQuery.getFolderChildPickPagination(command.userId(),
+			command.folderId(), command.cursor(), command.size());
 	}
 
 	@LoginUserIdDistributedLock

--- a/backend/baguni-domain/src/main/java/baguni/domain/infrastructure/folder/FolderDataHandler.java
+++ b/backend/baguni-domain/src/main/java/baguni/domain/infrastructure/folder/FolderDataHandler.java
@@ -20,6 +20,7 @@ import baguni.domain.exception.user.ApiUserException;
 public class FolderDataHandler {
 
 	private final FolderRepository folderRepository;
+	private final FolderQuery folderQuery;
 	private final UserRepository userRepository;
 
 	@Transactional
@@ -64,17 +65,17 @@ public class FolderDataHandler {
 
 	@Transactional(readOnly = true)
 	public Folder getRootFolder(Long userId) {
-		return folderRepository.findRootByUserId(userId);
+		return folderQuery.findRoot(userId);
 	}
 
 	@Transactional(readOnly = true)
 	public Folder getRecycleBin(Long userId) {
-		return folderRepository.findRecycleBinByUserId(userId);
+		return folderQuery.findRecycleBin(userId);
 	}
 
 	@Transactional(readOnly = true)
 	public Folder getUnclassifiedFolder(Long userId) {
-		return folderRepository.findUnclassifiedByUserId(userId);
+		return folderQuery.findUnclassified(userId);
 	}
 
 	@Transactional

--- a/backend/baguni-domain/src/main/java/baguni/domain/infrastructure/folder/FolderQuery.java
+++ b/backend/baguni-domain/src/main/java/baguni/domain/infrastructure/folder/FolderQuery.java
@@ -1,0 +1,51 @@
+package baguni.domain.infrastructure.folder;
+
+import static baguni.domain.model.folder.QFolder.*;
+
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import baguni.domain.model.folder.Folder;
+import baguni.domain.model.folder.FolderType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class FolderQuery {
+
+	private final JPAQueryFactory jpaQueryFactory;
+
+	public Folder findRoot(Long userId) {
+		return findByFolderType(userId, FolderType.ROOT);
+	}
+
+	public Folder findUnclassified(Long userId) {
+		return findByFolderType(userId, FolderType.UNCLASSIFIED);
+	}
+
+	public Folder findRecycleBin(Long userId) {
+		return findByFolderType(userId, FolderType.RECYCLE_BIN);
+	}
+
+	private Folder findByFolderType(Long userId, FolderType folderType) {
+		return jpaQueryFactory
+			.selectFrom(folder)
+			.where(
+				userEqCondition(userId),
+				folderTypeEqCondition(folderType)
+			)
+			.fetchOne();
+	}
+
+	private BooleanExpression userEqCondition(Long userId) {
+		return folder.user.id.eq(userId);
+	}
+
+	private BooleanExpression folderTypeEqCondition(FolderType folderType) {
+		return folder.folderType.eq(folderType);
+	}
+}

--- a/backend/baguni-domain/src/main/java/baguni/domain/infrastructure/folder/FolderRepository.java
+++ b/backend/baguni-domain/src/main/java/baguni/domain/infrastructure/folder/FolderRepository.java
@@ -26,20 +26,5 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
 
 	List<Folder> findByParentFolderId(Long parentFolderId);
 
-	// TODO: QueryDSL 도입 후 리팩토링 필요
-	@Query("SELECT f FROM Folder f WHERE f.user.id = :userId AND f.folderType = baguni.domain.model.folder.FolderType"
-		+ ".UNCLASSIFIED")
-	Folder findUnclassifiedByUserId(@Param("userId") Long userId);
-
-	// TODO: QueryDSL 도입 후 리팩토링 필요
-	@Query("SELECT f FROM Folder f WHERE f.user.id = :userId AND f.folderType = baguni.domain.model.folder.FolderType"
-		+ ".RECYCLE_BIN")
-	Folder findRecycleBinByUserId(@Param("userId") Long userId);
-
-	// TODO: QueryDSL 도입 후 리팩토링 필요
-	@Query("SELECT f FROM Folder f WHERE f.user.id = :userId AND f.folderType = baguni.domain.model.folder.FolderType"
-		+ ".ROOT")
-	Folder findRootByUserId(@Param("userId") Long userId);
-
 	void deleteByUserId(Long userId);
 }

--- a/backend/baguni-domain/src/main/java/baguni/domain/infrastructure/pick/PickQuery.java
+++ b/backend/baguni-domain/src/main/java/baguni/domain/infrastructure/pick/PickQuery.java
@@ -4,6 +4,7 @@ import static baguni.domain.model.folder.QFolder.*;
 import static baguni.domain.model.pick.QPick.*;
 import static baguni.domain.model.pick.QPickTag.*;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.StringTokenizer;
 import java.util.stream.Collectors;
@@ -34,8 +35,8 @@ public class PickQuery {
 
 	private final JPAQueryFactory jpaQueryFactory;
 
-	// TODO: 폴더 리스트 내 픽 조회 시 java sort vs querydsl 시간 측정 후 빠르면 사용 예정
-	//  Java sort에 비해 속도가 느린 것을 확인. 참고를 위해 코드 유지
+	// 폴더 리스트 내 픽 조회 시 java sort vs querydsl 시간 측정 용도
+	// Java sort에 비해 속도가 느린 것을 확인. 참고를 위해 코드 유지
 	public List<PickResult.Pick> getPickList(Long userId, List<Long> folderIdList) {
 		if (folderIdList == null || folderIdList.isEmpty()) {
 			return List.of();
@@ -49,26 +50,19 @@ public class PickQuery {
 			return List.of();
 		}
 
-		String orderListStr = pickIdList.stream()
-										.map(String::valueOf)
-										.collect(Collectors.joining(", "));
-
-		Expression<Integer> orderByField = Expressions.template(Integer.class,
-			"FIELD({0}, " + orderListStr + ")", pick.id);
-
-		OrderSpecifier<Integer> orderSpecifier = new OrderSpecifier<>(Order.ASC, orderByField);
-
 		return jpaQueryFactory
 			.select(pickResultFields())
 			.from(pick)
 			.where(
 				userEqCondition(userId)
 			)
-			.orderBy(orderSpecifier)
+			.orderBy(pickOrderSpecifier(pickIdList))
 			.fetch();
 	}
 
-	// TODO: 본인 픽이 아닌 다른 사람의 픽도 검색하고 싶다면 userId 부분 제거
+	/**
+	 * 픽 id 순으로 검색 결과가 출력
+	 */
 	public Slice<PickResult.Pick> searchPickPagination(
 		Long userId, List<Long> folderIdList, List<String> searchTokenList,
 		List<Long> tagIdList, Long cursor, int size
@@ -80,7 +74,7 @@ public class PickQuery {
 			.leftJoin(pickTag).on(pick.id.eq(pickTag.pick.id))
 			.where(
 				userEqCondition(userId), // 본인 pick 조회
-				folderIdCondition(folderIdList), // 폴더에 해당 하는 pick 조회
+				folderIdListCondition(folderIdList), // 폴더에 해당 하는 pick 조회
 				searchTokenListCondition(searchTokenList), // 제목 검색 조건
 				tagIdListCondition(tagIdList), // 태그 검색 조건
 				cursorIdCondition(cursor) // 페이지네이션 조건
@@ -101,6 +95,69 @@ public class PickQuery {
 		}
 
 		return new SliceImpl<>(pickList, PageRequest.ofSize(size), hasNext);
+	}
+
+	/**
+	 * 폴더 내에 있는 픽 리스트 순서 보장 때문에 생긴 문제
+	 * 폴더 엔티티의 childPickList가 String으로 저장되므로 DB에서 limit으로 잘라서 가져올 수 없음.
+	 * 전체 리스트 가져온 후 Java의 subList로 잘라야 함.
+	 * 결국 근본적인 원인은 관계 테이블이 없다는 문제, 관계 테이블이 있었다면 쉽게 잘라서 가져올 수 있음.
+	 *
+	 * 개선 방법 : 관계 테이블을 두고, sequence라는 순서 필드를 생성
+	 * 각 요소마다 간격을 100 또는 1000을 둔다.
+	 * 맨 앞에 삽입하는 경우 (0+100) / 2 = 50
+	 * 중간에 삽입하는 경우 (100+200) / 2 = 150
+	 * 이런 식으로 계속 반복하다가 더 이상 넣을 수 없는 경우 sequence 재설정 -> 첫 번째 100, 두 번째 200 ...
+	 */
+	public Slice<PickResult.Pick> getFolderChildPickPagination(Long userId, Long folderId, Long cursor, int size) {
+		List<Long> pickIdList = getChildPickIdOrderedList(folderId);
+
+		if (pickIdList == null || pickIdList.isEmpty()) {
+			return new SliceImpl<>(Collections.emptyList(), PageRequest.ofSize(size), false);
+		}
+
+		// cursor 기반 subList 뽑기
+		int cursorIndex = (cursor == null || cursor == 0) ? 0 : pickIdList.indexOf(cursor) + 1;
+
+		// cursor가 맨 마지막 요소인 경우 빈 리스트 반환
+		if (cursorIndex >= pickIdList.size()) {
+			return new SliceImpl<>(Collections.emptyList(), PageRequest.ofSize(size), false);
+		}
+
+		// 리스트 index 넘어가지 않도록 하기 위함.
+		int maxCount = size + 1;
+		int endIdx = Math.min(cursorIndex + maxCount, pickIdList.size());
+
+		List<Long> subPickIdList = pickIdList.subList(cursorIndex, endIdx);
+
+		boolean hasNext = false;
+		if (subPickIdList.size() > size) {
+			hasNext = true;
+			subPickIdList = subPickIdList.subList(0, size);
+		}
+
+		List<PickResult.Pick> pickList = jpaQueryFactory
+			.select(pickResultFields()) // dto로 반환
+			.from(pick)
+			.where(
+				userEqCondition(userId), // 본인 pick 조회
+				pickIdListCondition(subPickIdList) // 픽 idList에 포함되는 id
+			)
+			.orderBy(pickOrderSpecifier(subPickIdList))
+			.fetch();
+
+		return new SliceImpl<>(pickList, PageRequest.ofSize(size), hasNext);
+	}
+
+	private OrderSpecifier<Integer> pickOrderSpecifier(List<Long> pickIdList) {
+		String orderListStr = pickIdList.stream()
+										.map(String::valueOf)
+										.collect(Collectors.joining(", "));
+
+		Expression<Integer> orderByField = Expressions.template(Integer.class,
+			"FIELD({0}, " + orderListStr + ")", pick.id);
+
+		return new OrderSpecifier<>(Order.ASC, orderByField);
 	}
 
 	private ConstructorExpression<PickResult.Pick> pickResultFields() {
@@ -134,11 +191,19 @@ public class PickQuery {
 		return jpaQueryFactory
 			.select(folder.childPickIdOrderedList)
 			.from(folder)
-			.where(folder.id.eq(folderId))
+			.where(folderIdCondition(folderId))
 			.fetchOne();
 	}
 
-	private BooleanExpression folderIdCondition(List<Long> folderIdList) {
+	private BooleanExpression pickIdListCondition(List<Long> pickIdList) {
+		return pick.id.in(pickIdList);
+	}
+
+	private BooleanExpression folderIdCondition(Long folderId) {
+		return folder.id.eq(folderId);
+	}
+
+	private BooleanExpression folderIdListCondition(List<Long> folderIdList) {
 		if (folderIdList == null || folderIdList.isEmpty()) {
 			return null;
 		}

--- a/backend/baguni-domain/src/main/java/baguni/domain/infrastructure/pick/dto/PickCommand.java
+++ b/backend/baguni-domain/src/main/java/baguni/domain/infrastructure/pick/dto/PickCommand.java
@@ -12,6 +12,9 @@ public class PickCommand {
 	public record ReadList(Long userId, List<Long> folderIdList) {
 	}
 
+	public record ReadPagination(Long userId, Long folderId, Long cursor, int size) {
+	}
+
 	public record SearchPagination(Long userId, List<Long> folderIdList, List<String> searchTokenList,
 								   List<Long> tagIdList, Long cursor, int size) {
 	}


### PR DESCRIPTION
## What is this PR? 🔍

- 기능 : 모바일 뷰 폴더 리스트, 픽 페이지네이션 API
- issue : #1031, #1032

## Changes 📝
- 루트, 미분류, 휴지통 폴더 조회 jpql -> querydsl로 리팩토링
- 모바일에서 보여줄 폴더 리스트 API 구현
(미분류, 휴지통, 루트 하위 폴더 리스트 순)
- 픽 페이지네이션 API 구현
(폴더의 자식 픽 리스트를 DB에서 limit으로 잘라서 가져올 수 없는 문제 -> 전체 리스트 가져온 후 subList 이용)
(이후 관계 테이블 이용해서 리스트의 순서 보장해야 함)

## Precaution
querydsl을 사용하면서 관계 테이블 없이 데이터를 잘라서 가져올 수 없다는 것을 깨달음.
순서 리스트 리팩토링 들어가게 되면, 관계 테이블 도입해서 간격을 두는 방식은 어떤지?

## 로직 설명
리스트 : [40, 30, 11, 55, 32, 19, 33, 101, 3, 22, 88] 
1. 초기에 각 아이템에 sequence를 **10씩** 띄워 할당
   - 40 (sequence=10), 30 (sequence=20), 11 (sequence=30)
2. **맨 앞**에 새 아이템을 삽입할 때는, **기존 첫 아이템 seqence(10)보다 작은 값**(10/2 = 5)을 할당
3. 중간에 삽입할 때는 **“앞 아이템 seq”와 “뒤 아이템 seq”의 중간값**을 할당
   - 40 (sequence=10)과 30 (sequence=20) 사이에 삽입 -> ((20+10) / 2 = 15)

맨 앞에 계속 삽입하게 되면, 점점 더 작은 숫자(5 → 3 → 2 → 1 → 0 → -1 → …)가 되어버릴 수 있음.
중간 삽입도 앞 seq=20, 뒤 seq=21 사이에 삽입하려고 하면 더 이상 “중간값”을 할당하기 어려워짐.
이때 **리밸런싱(Rebalancing)** 과정이 필요.

### 새로운 간격으로 sequence를 할당(리밸런싱)
* 예: 10 단위
```java
int newSeq = 10;
for (FolderPick fp : folderPickList) {
    fp.setSequence(newSeq);
    newSeq += 10;
}
```
* 이렇게 하면 아이템 순서는 그대로 유지하지만, 10, 20, 30, … 처럼 **넉넉한 간격**을 다시 확보.
