### PR TITLE
[FIX] /folders/unclassified로 접속 시에 홈으로 리다이렉트

### DIFF
--- a/frontend/techpick/src/app/(signed)/folders/[folderId]/layout.tsx
+++ b/frontend/techpick/src/app/(signed)/folders/[folderId]/layout.tsx
@@ -1,16 +1,23 @@
 import { getPickListByFolderId } from '@/apis/pick/getPickListByFolderId';
+import { ROUTES } from '@/constants/route';
 import { getQueryClient } from '@/libs/@react-query/getQueryClient';
 import { pickKeys } from '@/queries/pickKeys';
 import { HydrationBoundary, dehydrate } from '@tanstack/react-query';
+import { redirect } from 'next/navigation';
+
 import type { PropsWithChildren } from 'react';
 
 export default async function FolderDetailLayout({
   params,
   children,
 }: PropsWithChildren<FolderDetailLayoutProps>) {
-  const queryClient = getQueryClient();
-
   const folderId = Number(params.folderId);
+
+  if (Number.isNaN(folderId) || folderId < 0) {
+    redirect(ROUTES.HOME);
+  }
+
+  const queryClient = getQueryClient();
 
   await queryClient.prefetchQuery({
     queryKey: pickKeys.folderId(folderId),

--- a/frontend/techpick/src/app/(signed)/folders/page.tsx
+++ b/frontend/techpick/src/app/(signed)/folders/page.tsx
@@ -2,5 +2,5 @@ import { ROUTES } from '@/constants/route';
 import { redirect } from 'next/navigation';
 
 export default function FolderPage() {
-  redirect(ROUTES.RECOMMEND);
+  redirect(ROUTES.HOME);
 }

--- a/frontend/techpick/src/constants/route.ts
+++ b/frontend/techpick/src/constants/route.ts
@@ -1,6 +1,5 @@
 export const ROUTES = {
   HOME: '/',
-  UNCLASSIFIED_FOLDER: '/folders',
   RECOMMEND: '/recommend',
   FOLDER_DETAIL: (folderId: number) => `/folders/${folderId}`,
   SEARCH: '/folders/search',


### PR DESCRIPTION
## What is this PR? 🔍
### `folders/unclassified`, `folder/recycle-bin` 등의 주소에 접근하면 /로 리다이렉트하게 변경.
SSR을 적용하면서 `folders/[folderId]` url일 때, folderId가 숫자가 아닌 문자(ex. unclassified, recycle-bin)로 접근하게 된다면 문제가 발생했습니다. 따라서 검증 로직을 추가하여 숫자일 때만 요청을 보내고, 그렇지 않을 때에는 리다이렉트 되게 변경했습니다.

- 기능 :
- #1036 
- #1020 

## Changes 📝

<!--
## ScreenShot 📷
이번 PR에서의 변경점

| Before                     | After                     |
| -------------------------- | ------------------------- |
| ![Before Image](링크_넣기) | ![After Image](링크_넣기) |
-->

## Precaution

<!-- ## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint` -->
