### PR TITLE
[FIX] 토큰 만료 관련 로그 제거

### DIFF
--- a/backend/baguni-api/src/main/java/baguni/security/handler/BaguniApiAuthExceptionEntrypoint.java
+++ b/backend/baguni-api/src/main/java/baguni/security/handler/BaguniApiAuthExceptionEntrypoint.java
@@ -44,7 +44,7 @@ public class BaguniApiAuthExceptionEntrypoint implements AuthenticationEntryPoin
 		HttpServletResponse response,
 		AuthenticationException exception
 	) throws IOException {
-		log.error(exception.getMessage(), exception);
+
 		var errorResponse = ApiErrorResponse.of(ApiAuthErrorCode.AUTH_INVALID_AUTHENTICATION);
 		var errorStatus = errorResponse.getStatusCode().value();
 		var body = errorResponse.getBody();


### PR DESCRIPTION
- Close #1046 

## What is this PR? 🔍

- issue : #1046 
- 내용
     - warning으로 낮추지 않고, **아예 로그를 삭제함.**
- 이유: 
     1. 관련 Response 에러 레벨이 `can-happen` (발생하는게 정상적 상황) 이다. 
     2. 이 예외는 식별되지 않은 사용자도 포함되기 때문에 (`eg. 토큰이 없어서 식별이 안된경우`)
         로그에서 특정 사용자에게 자주 발생한다~ 이런 정보를 얻기 어렵다.
- 결론:
    - 로그를 남김의 의미가 없다고 판단, 삭제함. 