### PR TITLE
[FEAT] 북마크 이미지 비율 변경 및 웹사이트 마우스로 텍스트 드래그 가능하게 변경

### DIFF
--- a/frontend/techpick/src/components/DragOverlay/PickRecordOverlay.tsx
+++ b/frontend/techpick/src/components/DragOverlay/PickRecordOverlay.tsx
@@ -13,6 +13,7 @@ import { PickTagColumnLayout } from '../PickRecord/PickTagColumnLayout';
 import { PickTitleColumnLayout } from '../PickRecord/PickTitleColumnLayout';
 import { Separator } from '../PickRecord/Separator';
 import {
+  backgroundImageStyle,
   dateTextStyle,
   externalLinkIconStyle,
   imageStyle,
@@ -39,13 +40,22 @@ export function PickRecordOverlay({ pickInfo }: PickViewItemComponentProps) {
       <PickImageColumnLayout>
         <div className={pickImageStyle}>
           {imageStatus === 'loaded' ? (
-            <img
-              src={link.imageUrl}
-              alt=""
-              width="96px"
-              height="47.25px"
-              className={imageStyle}
-            />
+            <>
+              <img
+                src={link.imageUrl}
+                alt=""
+                width="96px"
+                height="47.25px"
+                className={backgroundImageStyle}
+              />
+              <img
+                src={link.imageUrl}
+                alt=""
+                width="96px"
+                height="47.25px"
+                className={imageStyle}
+              />
+            </>
           ) : (
             <Image src="/image/default_image.svg" alt="" fill sizes="96px" />
           )}

--- a/frontend/techpick/src/components/PickRecord/PickDraggableRecord.tsx
+++ b/frontend/techpick/src/components/PickRecord/PickDraggableRecord.tsx
@@ -99,6 +99,13 @@ export function PickDraggableRecord({
     selectSinglePick(pickId);
   };
 
+  const handleMouseDown = (event: MouseEvent<HTMLDivElement>) => {
+    if (event.shiftKey) {
+      // 텍스트 선택 방지
+      event.preventDefault();
+    }
+  };
+
   /**
    * @description multi-select에 포함이 됐으나 dragging target이 아닐때.
    */
@@ -119,8 +126,9 @@ export function PickDraggableRecord({
       {/* biome-ignore lint/a11y/useKeyWithClickEvents: <explanation> */}
       <div
         className={`${isSelected ? selectedDragItemStyle : ''} ${isActiveDragging ? isActiveDraggingItemStyle : ''}`}
-        onClick={(event) => handleClick(pickId, event)}
         id={pickElementId}
+        onClick={(event) => handleClick(pickId, event)}
+        onMouseDown={handleMouseDown}
       >
         <PickContextMenu pickInfo={pickInfo}>
           <PickRecord pickInfo={pickInfo} />

--- a/frontend/techpick/src/components/PickRecord/PickRecord.tsx
+++ b/frontend/techpick/src/components/PickRecord/PickRecord.tsx
@@ -21,6 +21,7 @@ import { PickTagColumnLayout } from './PickTagColumnLayout';
 import { PickTitleColumnLayout } from './PickTitleColumnLayout';
 import { Separator } from './Separator';
 import {
+  backgroundImageStyle,
   dateTextStyle,
   externalLinkIconStyle,
   imageStyle,
@@ -71,13 +72,22 @@ export function PickRecord({ pickInfo }: PickViewItemComponentProps) {
           {imageStatus === 'loading' && <div />}
 
           {imageStatus === 'loaded' && (
-            <img
-              src={link.imageUrl}
-              alt=""
-              width="96px"
-              height="47.25px"
-              className={imageStyle}
-            />
+            <>
+              <img
+                src={link.imageUrl}
+                alt=""
+                width="96px"
+                height="47.25px"
+                className={backgroundImageStyle}
+              />
+              <img
+                src={link.imageUrl}
+                alt=""
+                width="96px"
+                height="47.25px"
+                className={imageStyle}
+              />
+            </>
           )}
 
           {imageStatus === 'error' && (

--- a/frontend/techpick/src/components/PickRecord/pickRecord.css.ts
+++ b/frontend/techpick/src/components/PickRecord/pickRecord.css.ts
@@ -61,4 +61,14 @@ export const externalLinkIconStyle = style({
   color: colorVars.white,
 });
 
-export const imageStyle = style({ objectFit: 'cover' });
+export const backgroundImageStyle = style({
+  objectFit: 'cover',
+  opacity: '0.3',
+});
+
+export const imageStyle = style({
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  objectFit: 'scale-down',
+});

--- a/frontend/techpick/src/styles/reset.css.ts
+++ b/frontend/techpick/src/styles/reset.css.ts
@@ -3,7 +3,6 @@ import { globalStyle } from '@vanilla-extract/css';
 globalStyle('*', {
   boxSizing: 'border-box',
   backgroundColor: 'transparent',
-  userSelect: 'none',
 });
 
 globalStyle('*::-webkit-scrollbar', {


### PR DESCRIPTION
- Close #957 
- Close #1027 

## What is this PR? 🔍
### 북마크 이미지 비율 변경
- #957 

OG image가 있다면 좋지만, OG image가 없는 경우에 파비콘이 사용되는데 크기에 비해 이미지가 작은 경우가 존재했습니다. 해당 디자인을 개선했습니다.
![K-005](https://github.com/user-attachments/assets/40cfcb48-6967-44f2-a9b4-5f3a123fbca9)

다만 추천 페이지에서는 적용을 하지 않았는데 그 이유는 이미지 영역에 비해 크기가 작아서 오히려 이상한 느낌을 주기 때문입니다.
![K-006](https://github.com/user-attachments/assets/1bd97b50-a472-40fc-a831-6260f765aa94)

### 웹사이트 마우스로 텍스트 드래그 가능하게 변경
- #1027 

텍스트를 드래그할 수 없게(긁을 수 없게) 해놨습니다. 그래서 드래그해서 검색하거나 복사할 수 없는 불편함이 존재했습니다. 이는 멀티 셀렉트(shift+click)시에 텍스트가 파랗게 드래그 되었다가 사라지는 경험을 없애기 위해서였고 기존의 `user-select` 로 막는 대신, onMouseDown의 기본 동작을 막음으로서 개선했습니다.


<!--
## ScreenShot 📷
이번 PR에서의 변경점

| Before                     | After                     |
| -------------------------- | ------------------------- |
| ![Before Image](링크_넣기) | ![After Image](링크_넣기) |
-->

## Precaution

<!-- ## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint` -->
