### PR TITLE
[CHORE] OpenTelemetry 로그 형식으로 로그백 수정 (콘솔은 유지)

### DIFF
--- a/backend/baguni-api/src/main/resources/logback-spring.xml
+++ b/backend/baguni-api/src/main/resources/logback-spring.xml
@@ -33,101 +33,50 @@
         </encoder>
     </appender>
 
-    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
-                <maxFileSize>100MB</maxFileSize>
-            </timeBasedFileNamingAndTriggeringPolicy>
-            <fileNamePattern>${LOG_PATH}/${DATE_DIR}/application.%i.log</fileNamePattern>
-        </rollingPolicy>
-        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
-            <timestampPattern>yyyy-MM-dd'T'HH:mm:ss.SSS</timestampPattern>
-            <!-- https://github.com/logfellow/logstash-logback-encoder?tab=readme-ov-file#standard-fields -->
-            <fieldNames>
-                <timestamp>timestamp</timestamp>
-                <level>level</level>
-                <thread>thread</thread>
-                <logger>logger</logger>
-                <message>message</message>
-                <stackTrace>stackTrace</stackTrace>
-                <levelValue>[ignore]</levelValue>
-                <version>[ignore]</version>
-            </fieldNames>
-            <includeMdcKeyName>traceId</includeMdcKeyName>
-            <includeMdcKeyName>spanId</includeMdcKeyName>
-            <customFields>{"appname":"${APPLICATION_NAME}"}</customFields>
-        </encoder>
-    </appender>
+    <!--  메트릭, 트레이스 뿐 아니라 log.info(...) 같이 로그로 찍은 데이터도 OTEL로 전송해야 한다. -->
+    <appender name="OpenTelemetry" class="io.opentelemetry.instrumentation.logback.appender.v1_0.OpenTelemetryAppender"/>
 
     <!-- ````````````````````````````````````````````````` -->
     <!--                 Logger Setting                    -->
     <!-- ````````````````````````````````````````````````` -->
     <springProfile name="local">
-        <logger name="p6spy" level="info" additivity="false">
-            <appender-ref ref="CONSOLE"/>
-        </logger>
+        <logger name="org.hibernate.orm.jdbc.bind" level="trace" additivity="false"/> <!-- exclude from console -->
+        <logger name="org.hibernate.SQL" level="debug" additivity="false"/> <!-- exclude from console -->
         <logger name="org.hibernate" level="debug" additivity="false">
             <appender-ref ref="CONSOLE"/>
         </logger>
-        <logger name="com.zaxxer.hikari.pool.HikariPool" level="debug" additivity="false">
+        <root level="INFO">
             <appender-ref ref="CONSOLE"/>
-        </logger>
-        <logger name="org.hibernate.SQL" level="debug" additivity="false"/> <!-- exclude from console -->
-        <logger name="org.hibernate.orm.jdbc.bind" level="trace" additivity="false"/> <!-- exclude from console -->
-        <logger name="org.flywaydb" level="info" additivity="false">
-            <appender-ref ref="CONSOLE"/>
-        </logger>
-        <logger name="baguni" level="info" additivity="false">
-            <appender-ref ref="CONSOLE"/>
-        </logger>
+        </root>
     </springProfile>
 
     <springProfile name="dev">
+        <logger name="org.hibernate.orm.jdbc.bind" level="trace" additivity="false"/> <!-- exclude from console -->
+        <logger name="org.hibernate.SQL" level="debug" additivity="false"/> <!-- exclude from console -->
         <logger name="p6spy" level="info" additivity="false">
             <appender-ref ref="CONSOLE"/>
         </logger>
-        <logger name="com.zaxxer.hikari.pool.HikariPool" level="debug" additivity="false">
-            <appender-ref ref="CONSOLE"/>
-            <appender-ref ref="FILE"/>
-        </logger>
         <logger name="org.hibernate" level="debug" additivity="false">
             <appender-ref ref="CONSOLE"/>
-            <appender-ref ref="FILE"/>
+            <appender-ref ref="OpenTelemetry"/>
         </logger>
-        <logger name="org.hibernate.SQL" level="debug" additivity="false">
-            <appender-ref ref="FILE"/>  <!-- save sql to file without p6spy -->
-        </logger>
-        <logger name="org.hibernate.orm.jdbc.bind" level="trace" additivity="false">
-            <appender-ref ref="FILE"/>  <!-- save sql to file without p6spy -->
-        </logger>
-        <logger name="org.flywaydb" level="info" additivity="false">
+        <root level="INFO">
             <appender-ref ref="CONSOLE"/>
-            <appender-ref ref="FILE"/>
-        </logger>
-        <logger name="baguni" level="info" additivity="false">
-            <appender-ref ref="CONSOLE"/>
-            <appender-ref ref="FILE"/>
-        </logger>
+            <appender-ref ref="OpenTelemetry"/>
+        </root>
     </springProfile>
 
     <springProfile name="prod">
-        <!--  p6spy는 운영 서버에서 사용 X  -->
+        <logger name="org.hibernate.orm.jdbc.bind" level="trace" additivity="false"/> <!-- exclude query -->
+        <logger name="org.hibernate.SQL" level="debug" additivity="false"/> <!-- exclude query -->
         <logger name="org.hibernate" level="debug" additivity="false">
             <appender-ref ref="CONSOLE"/>
-            <appender-ref ref="FILE"/>
+            <appender-ref ref="OpenTelemetry"/>
         </logger>
-        <logger name="com.zaxxer.hikari.pool.HikariPool" level="debug" additivity="false">
+        <root level="INFO">
             <appender-ref ref="CONSOLE"/>
-            <appender-ref ref="FILE"/>
-        </logger>
-        <logger name="org.flywaydb" level="info" additivity="false">
-            <appender-ref ref="CONSOLE"/>
-            <appender-ref ref="FILE"/>
-        </logger>
-        <logger name="baguni" level="info" additivity="false">
-            <appender-ref ref="CONSOLE"/>
-            <appender-ref ref="FILE"/>
-        </logger>
+            <appender-ref ref="OpenTelemetry"/>
+        </root>
     </springProfile>
 
 </configuration>

--- a/backend/baguni-batch/src/main/resources/logback-spring.xml
+++ b/backend/baguni-batch/src/main/resources/logback-spring.xml
@@ -33,101 +33,50 @@
         </encoder>
     </appender>
 
-    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
-                <maxFileSize>100MB</maxFileSize>
-            </timeBasedFileNamingAndTriggeringPolicy>
-            <fileNamePattern>${LOG_PATH}/${DATE_DIR}/application.%i.log</fileNamePattern>
-        </rollingPolicy>
-        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
-            <timestampPattern>yyyy-MM-dd'T'HH:mm:ss.SSS</timestampPattern>
-            <!-- https://github.com/logfellow/logstash-logback-encoder?tab=readme-ov-file#standard-fields -->
-            <fieldNames>
-                <timestamp>timestamp</timestamp>
-                <level>level</level>
-                <thread>thread</thread>
-                <logger>logger</logger>
-                <message>message</message>
-                <stackTrace>stackTrace</stackTrace>
-                <levelValue>[ignore]</levelValue>
-                <version>[ignore]</version>
-            </fieldNames>
-            <includeMdcKeyName>traceId</includeMdcKeyName>
-            <includeMdcKeyName>spanId</includeMdcKeyName>
-            <customFields>{"appname":"${APPLICATION_NAME}"}</customFields>
-        </encoder>
-    </appender>
+    <!--  메트릭, 트레이스 뿐 아니라 log.info(...) 같이 로그로 찍은 데이터도 OTEL로 전송해야 한다. -->
+    <appender name="OpenTelemetry" class="io.opentelemetry.instrumentation.logback.appender.v1_0.OpenTelemetryAppender"/>
 
     <!-- ````````````````````````````````````````````````` -->
     <!--                 Logger Setting                    -->
     <!-- ````````````````````````````````````````````````` -->
     <springProfile name="local">
-        <logger name="p6spy" level="info" additivity="false">
-            <appender-ref ref="CONSOLE"/>
-        </logger>
+        <logger name="org.hibernate.orm.jdbc.bind" level="trace" additivity="false"/> <!-- exclude from console -->
+        <logger name="org.hibernate.SQL" level="debug" additivity="false"/> <!-- exclude from console -->
         <logger name="org.hibernate" level="debug" additivity="false">
             <appender-ref ref="CONSOLE"/>
         </logger>
-        <logger name="com.zaxxer.hikari.pool.HikariPool" level="debug" additivity="false">
+        <root level="INFO">
             <appender-ref ref="CONSOLE"/>
-        </logger>
-        <logger name="org.hibernate.SQL" level="debug" additivity="false"/> <!-- exclude from console -->
-        <logger name="org.hibernate.orm.jdbc.bind" level="trace" additivity="false"/> <!-- exclude from console -->
-        <logger name="org.flywaydb" level="info" additivity="false">
-            <appender-ref ref="CONSOLE"/>
-        </logger>
-        <logger name="baguni" level="info" additivity="false">
-            <appender-ref ref="CONSOLE"/>
-        </logger>
+        </root>
     </springProfile>
 
     <springProfile name="dev">
+        <logger name="org.hibernate.orm.jdbc.bind" level="trace" additivity="false"/> <!-- exclude from console -->
+        <logger name="org.hibernate.SQL" level="debug" additivity="false"/> <!-- exclude from console -->
         <logger name="p6spy" level="info" additivity="false">
             <appender-ref ref="CONSOLE"/>
         </logger>
-        <logger name="com.zaxxer.hikari.pool.HikariPool" level="debug" additivity="false">
-            <appender-ref ref="CONSOLE"/>
-            <appender-ref ref="FILE"/>
-        </logger>
         <logger name="org.hibernate" level="debug" additivity="false">
             <appender-ref ref="CONSOLE"/>
-            <appender-ref ref="FILE"/>
+            <appender-ref ref="OpenTelemetry"/>
         </logger>
-        <logger name="org.hibernate.SQL" level="debug" additivity="false">
-            <appender-ref ref="FILE"/>  <!-- save sql to file without p6spy -->
-        </logger>
-        <logger name="org.hibernate.orm.jdbc.bind" level="trace" additivity="false">
-            <appender-ref ref="FILE"/>  <!-- save sql to file without p6spy -->
-        </logger>
-        <logger name="org.flywaydb" level="info" additivity="false">
+        <root level="INFO">
             <appender-ref ref="CONSOLE"/>
-            <appender-ref ref="FILE"/>
-        </logger>
-        <logger name="baguni" level="info" additivity="false">
-            <appender-ref ref="CONSOLE"/>
-            <appender-ref ref="FILE"/>
-        </logger>
+            <appender-ref ref="OpenTelemetry"/>
+        </root>
     </springProfile>
 
     <springProfile name="prod">
-        <!--  p6spy는 운영 서버에서 사용 X  -->
+        <logger name="org.hibernate.orm.jdbc.bind" level="trace" additivity="false"/> <!-- exclude query -->
+        <logger name="org.hibernate.SQL" level="debug" additivity="false"/> <!-- exclude query -->
         <logger name="org.hibernate" level="debug" additivity="false">
             <appender-ref ref="CONSOLE"/>
-            <appender-ref ref="FILE"/>
+            <appender-ref ref="OpenTelemetry"/>
         </logger>
-        <logger name="com.zaxxer.hikari.pool.HikariPool" level="debug" additivity="false">
+        <root level="INFO">
             <appender-ref ref="CONSOLE"/>
-            <appender-ref ref="FILE"/>
-        </logger>
-        <logger name="org.flywaydb" level="info" additivity="false">
-            <appender-ref ref="CONSOLE"/>
-            <appender-ref ref="FILE"/>
-        </logger>
-        <logger name="baguni" level="info" additivity="false">
-            <appender-ref ref="CONSOLE"/>
-            <appender-ref ref="FILE"/>
-        </logger>
+            <appender-ref ref="OpenTelemetry"/>
+        </root>
     </springProfile>
 
 </configuration>

--- a/backend/baguni-common/build.gradle
+++ b/backend/baguni-common/build.gradle
@@ -27,11 +27,6 @@ dependencies {
     // spring caffeine cache
     implementation 'org.springframework.boot:spring-boot-starter-cache'
     implementation 'com.github.ben-manes.caffeine:caffeine'
-
-    // spring tracing (request trace id & span id)
-    implementation 'org.springframework.boot:spring-boot-starter-actuator'
-    // ---- bridges the Micrometer Observation API to OpenTelemetry.
-    implementation 'io.micrometer:micrometer-tracing-bridge-otel'
 }
 
 

--- a/backend/baguni-common/src/main/resources/application-common.yaml
+++ b/backend/baguni-common/src/main/resources/application-common.yaml
@@ -1,10 +1,9 @@
-# By default, Spring Boot samples only 10% of requests to prevent overwhelming the trace backend.
-# This property switches it to 100% so that every request is sent to the trace backend.
-# Reference: https://docs.spring.io/spring-boot/reference/actuator/tracing.html
-management:
-  tracing:
-    sampling:
-      probability: 1
+# versions 2.0+ of the Java agent and OpenTelemetry Spring Boot starter
+# use http/protobuf as the default protocol, not grpc.
+otel:
+  exporter:
+    otlp:
+      endpoint: http://mornitor-alloy:4318
 ---
 spring:
   config:

--- a/backend/baguni-ranking/src/main/resources/logback-spring.xml
+++ b/backend/baguni-ranking/src/main/resources/logback-spring.xml
@@ -33,101 +33,50 @@
         </encoder>
     </appender>
 
-    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
-                <maxFileSize>100MB</maxFileSize>
-            </timeBasedFileNamingAndTriggeringPolicy>
-            <fileNamePattern>${LOG_PATH}/${DATE_DIR}/application.%i.log</fileNamePattern>
-        </rollingPolicy>
-        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
-            <timestampPattern>yyyy-MM-dd'T'HH:mm:ss.SSS</timestampPattern>
-            <!-- https://github.com/logfellow/logstash-logback-encoder?tab=readme-ov-file#standard-fields -->
-            <fieldNames>
-                <timestamp>timestamp</timestamp>
-                <level>level</level>
-                <thread>thread</thread>
-                <logger>logger</logger>
-                <message>message</message>
-                <stackTrace>stackTrace</stackTrace>
-                <levelValue>[ignore]</levelValue>
-                <version>[ignore]</version>
-            </fieldNames>
-            <includeMdcKeyName>traceId</includeMdcKeyName>
-            <includeMdcKeyName>spanId</includeMdcKeyName>
-            <customFields>{"appname":"${APPLICATION_NAME}"}</customFields>
-        </encoder>
-    </appender>
+    <!--  메트릭, 트레이스 뿐 아니라 log.info(...) 같이 로그로 찍은 데이터도 OTEL로 전송해야 한다. -->
+    <appender name="OpenTelemetry" class="io.opentelemetry.instrumentation.logback.appender.v1_0.OpenTelemetryAppender"/>
 
     <!-- ````````````````````````````````````````````````` -->
     <!--                 Logger Setting                    -->
     <!-- ````````````````````````````````````````````````` -->
     <springProfile name="local">
-        <logger name="p6spy" level="info" additivity="false">
-            <appender-ref ref="CONSOLE"/>
-        </logger>
+        <logger name="org.hibernate.orm.jdbc.bind" level="trace" additivity="false"/> <!-- exclude from console -->
+        <logger name="org.hibernate.SQL" level="debug" additivity="false"/> <!-- exclude from console -->
         <logger name="org.hibernate" level="debug" additivity="false">
             <appender-ref ref="CONSOLE"/>
         </logger>
-        <logger name="com.zaxxer.hikari.pool.HikariPool" level="debug" additivity="false">
+        <root level="INFO">
             <appender-ref ref="CONSOLE"/>
-        </logger>
-        <logger name="org.hibernate.SQL" level="debug" additivity="false"/> <!-- exclude from console -->
-        <logger name="org.hibernate.orm.jdbc.bind" level="trace" additivity="false"/> <!-- exclude from console -->
-        <logger name="org.flywaydb" level="info" additivity="false">
-            <appender-ref ref="CONSOLE"/>
-        </logger>
-        <logger name="baguni" level="info" additivity="false">
-            <appender-ref ref="CONSOLE"/>
-        </logger>
+        </root>
     </springProfile>
 
     <springProfile name="dev">
+        <logger name="org.hibernate.orm.jdbc.bind" level="trace" additivity="false"/> <!-- exclude from console -->
+        <logger name="org.hibernate.SQL" level="debug" additivity="false"/> <!-- exclude from console -->
         <logger name="p6spy" level="info" additivity="false">
             <appender-ref ref="CONSOLE"/>
         </logger>
-        <logger name="com.zaxxer.hikari.pool.HikariPool" level="debug" additivity="false">
-            <appender-ref ref="CONSOLE"/>
-            <appender-ref ref="FILE"/>
-        </logger>
         <logger name="org.hibernate" level="debug" additivity="false">
             <appender-ref ref="CONSOLE"/>
-            <appender-ref ref="FILE"/>
+            <appender-ref ref="OpenTelemetry"/>
         </logger>
-        <logger name="org.hibernate.SQL" level="debug" additivity="false">
-            <appender-ref ref="FILE"/>  <!-- save sql to file without p6spy -->
-        </logger>
-        <logger name="org.hibernate.orm.jdbc.bind" level="trace" additivity="false">
-            <appender-ref ref="FILE"/>  <!-- save sql to file without p6spy -->
-        </logger>
-        <logger name="org.flywaydb" level="info" additivity="false">
+        <root level="INFO">
             <appender-ref ref="CONSOLE"/>
-            <appender-ref ref="FILE"/>
-        </logger>
-        <logger name="baguni" level="info" additivity="false">
-            <appender-ref ref="CONSOLE"/>
-            <appender-ref ref="FILE"/>
-        </logger>
+            <appender-ref ref="OpenTelemetry"/>
+        </root>
     </springProfile>
 
     <springProfile name="prod">
-        <!--  p6spy는 운영 서버에서 사용 X  -->
+        <logger name="org.hibernate.orm.jdbc.bind" level="trace" additivity="false"/> <!-- exclude query -->
+        <logger name="org.hibernate.SQL" level="debug" additivity="false"/> <!-- exclude query -->
         <logger name="org.hibernate" level="debug" additivity="false">
             <appender-ref ref="CONSOLE"/>
-            <appender-ref ref="FILE"/>
+            <appender-ref ref="OpenTelemetry"/>
         </logger>
-        <logger name="com.zaxxer.hikari.pool.HikariPool" level="debug" additivity="false">
+        <root level="INFO">
             <appender-ref ref="CONSOLE"/>
-            <appender-ref ref="FILE"/>
-        </logger>
-        <logger name="org.flywaydb" level="info" additivity="false">
-            <appender-ref ref="CONSOLE"/>
-            <appender-ref ref="FILE"/>
-        </logger>
-        <logger name="baguni" level="info" additivity="false">
-            <appender-ref ref="CONSOLE"/>
-            <appender-ref ref="FILE"/>
-        </logger>
+            <appender-ref ref="OpenTelemetry"/>
+        </root>
     </springProfile>
 
 </configuration>

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -19,11 +19,18 @@ configurations {
         extendsFrom annotationProcessor
     }
 }
+
 subprojects {
     apply plugin: 'java'
     apply plugin: 'org.springframework.boot'
     apply plugin: 'io.spring.dependency-management'
     apply plugin: 'java-library'
+
+    dependencyManagement {
+        imports { //  import an existing Maven bom to utilise its dependency management,
+            mavenBom("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom:2.12.0")
+        }
+    }
 
     repositories {
         mavenCentral()
@@ -36,6 +43,9 @@ subprojects {
         implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.17.2'
         implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+        // opentelemetry spring boot starter
+        implementation "io.opentelemetry.instrumentation:opentelemetry-spring-boot-starter"
+
         // lombok annotation
         compileOnly 'org.projectlombok:lombok'
         annotationProcessor 'org.projectlombok:lombok'
@@ -44,10 +54,8 @@ subprojects {
 
         // logback logger
         implementation 'ch.qos.logback:logback-classic:1.4.12'
+        implementation 'ch.qos.logback.contrib:logback-json-classic:0.1.5' // remove later. no need to log file
         implementation 'org.slf4j:slf4j-api:2.0.3'
-
-        // logback - json 형태로 로그 출력
-        implementation 'net.logstash.logback:logstash-logback-encoder:8.0'
 
         // test environment
         testImplementation 'org.springframework.boot:spring-boot-starter-test'


### PR DESCRIPTION
- Close #1048 

## What is this PR? 🔍

- 기능 : 로그백을 OpenTelemety 로그 포맷으로 변경했습니다.
            그 과정에서, SQL 부분은 콘솔에만 찍히도록 변경했는데
            왜냐면 OpenTelemetry + LGTM 스택으로 가면서 Trace에 자동으로 SQL문이 포함되서 기록되기 때문에
            로그파일로 저장할 필요가 없어졌습니다.
            (굳이 로그백으로 찍지 않아도 된다는 말)
- 참고 : LGTM 설정이 마무리 되어 SQL문이 실행 시간과 함께 자동 측정됩니다. 
           개발 / 운영 서버에 반영해야 하기에 상세 사항은 수요일에 만나서 공유 드릴께요!
- 토의 필요 :
          :warning: 히카리CP 풀 로그가 자주 / 많이 찍혀서 로그 보기 어렵습니다.
                            이건 로그로 남기지 않고 Prometeus로 Metric 수집하는 식으로 변경하려 합니다.
                            의견 주세요!
### 로컬 적용 결과 (개발서버 아님!)
- Request별 각 실행 소요 시간 및 SQL 쿼리 측정
![image](https://github.com/user-attachments/assets/a498bac8-0d58-446b-bd8a-48b4f5a63676)
- Trace 별로 보기
![image](https://github.com/user-attachments/assets/f4a1d31a-d124-4b30-b4cb-d144d34667c7)
- issue : #1048 