### PR TITLE
[FIX] Pick 조회 API에서 조회수 데이터 제거

### DIFF
--- a/backend/baguni-api/src/main/java/baguni/api/application/pick/controller/PickApiController.java
+++ b/backend/baguni-api/src/main/java/baguni/api/application/pick/controller/PickApiController.java
@@ -50,7 +50,7 @@ public class PickApiController {
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "픽 리스트 조회 성공")
 	})
-	public ResponseEntity<List<PickApiResponse.FolderPickListWithViewCount>> getFolderChildPickList(
+	public ResponseEntity<List<PickApiResponse.FolderPickList>> getFolderChildPickList(
 		@LoginUserId Long userId,
 		@Parameter(description = "조회할 폴더 ID 목록", example = "1, 2, 3")
 		@RequestParam(required = false, defaultValue = "")
@@ -61,7 +61,7 @@ public class PickApiController {
 		);
 		return ResponseEntity.ok(
 			folderPickList.stream()
-						  .map(pickApiMapper::toApiFolderPickListWithViewCount)
+						  .map(pickApiMapper::toApiFolderPickList)
 						  .toList());
 	}
 
@@ -84,7 +84,8 @@ public class PickApiController {
 				예시: lastCursor = 1 → 다음 요청에 cursor=1을 넣으면, 1은 제외하고 2부터 조회합니다.
 			""",
 			example = "0") @RequestParam(required = false, defaultValue = "0") Long cursor,
-		@Parameter(description = "한 페이지에 가져올 픽 개수", example = "20") @RequestParam(required = false, defaultValue = "20") int size
+		@Parameter(description = "한 페이지에 가져올 픽 개수", example = "20") @RequestParam(required = false, defaultValue = "20"
+		) int size
 	) {
 		var command = pickApiMapper.toReadPaginationCommand(userId, folderId, cursor, size);
 		var pickList = pickService.getFolderListChildPickPagination(command);

--- a/backend/baguni-api/src/main/java/baguni/api/application/pick/dto/PickApiMapper.java
+++ b/backend/baguni-api/src/main/java/baguni/api/application/pick/dto/PickApiMapper.java
@@ -40,32 +40,13 @@ public interface PickApiMapper {
 
 	PickCommand.Delete toDeleteCommand(Long userId, PickApiRequest.Delete request);
 
-	PickApiResponse.PickWithViewCount toApiResponseWithPickViewCount(PickResult.PickWithViewCount pickResult);
-
 	PickApiResponse.Pick toApiResponse(PickResult.Pick pickResult);
 
 	PickApiResponse.Extension toApiExtensionResponse(PickResult.Extension pickResult);
 
 	PickApiResponse.Exist toApiExistResponse(Boolean exist);
 
-	@Named("mapPickList")
-	default List<PickApiResponse.Pick> mapPickList(List<PickResult.Pick> pickList) {
-		return pickList.stream()
-					   .map(this::toApiResponse)
-					   .toList();
-	}
-
-	@Mapping(target = "pickList", source = "pickList", qualifiedByName = "mapPickListWithViewCount")
-	PickApiResponse.FolderPickListWithViewCount toApiFolderPickListWithViewCount(
-		PickResult.FolderPickWithViewCountList folderPickList);
-
-	@Named("mapPickListWithViewCount")
-	default List<PickApiResponse.PickWithViewCount> mapPickListWithViewCount(
-		List<PickResult.PickWithViewCount> pickList) {
-		return pickList.stream()
-					   .map(this::toApiResponseWithPickViewCount)
-					   .toList();
-	}
+	PickApiResponse.FolderPickList toApiFolderPickList(PickResult.FolderPickList folderPickLists);
 
 	default PickSliceResponse<PickApiResponse.Pick> toSliceApiResponse(Slice<PickResult.Pick> source) {
 		List<PickApiResponse.Pick> convertedContent = source.getContent().stream()

--- a/backend/baguni-api/src/main/java/baguni/api/application/pick/dto/PickApiResponse.java
+++ b/backend/baguni-api/src/main/java/baguni/api/application/pick/dto/PickApiResponse.java
@@ -27,21 +27,6 @@ public class PickApiResponse {
 		List<Long> tagIdOrderedList,
 		LocalDateTime createdAt,
 		LocalDateTime updatedAt
-	){
-	}
-
-	public record PickWithViewCount(
-		Long id,
-		String title,
-		LinkInfo linkInfo,
-		Long parentFolderId,
-		List<Long> tagIdOrderedList,
-		LocalDateTime createdAt,
-		LocalDateTime updatedAt,
-		// 프론트엔드에서 깔끔하게 처리하기 위한 힌트
-		@NotNull Boolean isHot,
-		// 랭킹 정보에 표시된 최근 7일간 조회수
-		Long weeklyViewCount
 	) {
 	}
 
@@ -51,26 +36,8 @@ public class PickApiResponse {
 	) {
 	}
 
-	public record FolderPickListWithViewCount(
-		Long folderId,
-		List<PickApiResponse.PickWithViewCount> pickList
-	) {
-	}
-
-	public record PickExists(
-		@NotNull Boolean exist,
-		PickApiResponse.Pick pick
-	) {
-	}
-
 	public record Exist(
 		@NotNull Boolean exist
-	){
-	}
-
-	public record CreateFromRecommend(
-		boolean exist,
-		PickResult.Pick pick
 	) {
 	}
 }

--- a/backend/baguni-domain/src/main/java/baguni/domain/infrastructure/pick/dto/PickMapper.java
+++ b/backend/baguni-domain/src/main/java/baguni/domain/infrastructure/pick/dto/PickMapper.java
@@ -28,12 +28,9 @@ public interface PickMapper {
 	@Mapping(source = "pick.parentFolder.id", target = "parentFolderId")
 	PickResult.Extension toExtensionResult(Pick pick);
 
-	PickResult.PickWithViewCount toPickResultWithViewCount(PickResult.Pick pickResult, Boolean isHot,
-		Long weeklyViewCount);
-
 	@Mapping(source = "folderId", target = "folderId")
 	@Mapping(source = "pick", target = "pickList")
-	PickResult.FolderPickWithViewCountList toPickResultList(Long folderId, List<PickResult.PickWithViewCount> pick);
+	PickResult.FolderPickList toPickResultList(Long folderId, List<PickResult.Pick> pick);
 
 	@Mapping(source = "command.title", target = "title")
 	@Mapping(source = "command.tagIdOrderedList", target = "tagIdOrderedList")

--- a/backend/baguni-domain/src/main/java/baguni/domain/infrastructure/pick/dto/PickResult.java
+++ b/backend/baguni-domain/src/main/java/baguni/domain/infrastructure/pick/dto/PickResult.java
@@ -30,30 +30,9 @@ public class PickResult {
 	) {
 	}
 
-	public record PickWithViewCount(
-		Long id,
-		String title,
-		LinkInfo linkInfo,
-		Long parentFolderId,
-		List<Long> tagIdOrderedList,
-		LocalDateTime createdAt,
-		LocalDateTime updatedAt,
-		// 프론트엔드에서 깔끔하게 처리하기 위한 힌트
-		Boolean isHot,
-		// 랭킹 정보에 표시된 최근 7일간 조회수
-		Long weeklyViewCount
-	) {
-	}
-
 	public record FolderPickList(
 		Long folderId,
 		List<PickResult.Pick> pickList
-	) {
-	}
-
-	public record FolderPickWithViewCountList(
-		Long folderId,
-		List<PickResult.PickWithViewCount> pickList
 	) {
 	}
 }


### PR DESCRIPTION
- Close #1065 

## What is this PR? 🔍

- 수정 :  `픽 조회 API`에서 랭킹 데이터 제거 (`isHot`, `viewCount` 필드 제거)
- issue : #1065 

1. :warning: 해당 부분 제거된 이후 성능 재측정 해볼 예정
2. :warning: 미사용 DTO 필드 삭제하면서 테스트 코드도 변경 필요 (`제가 다음 PR에서 진행하겠습니다`)