### PR TITLE
[FEAT] 봇이 아닐 때만 방문 log 찍기

### DIFF
--- a/frontend/techpick/src/components/ScreenLogger.tsx
+++ b/frontend/techpick/src/components/ScreenLogger.tsx
@@ -17,7 +17,7 @@ export async function ScreenLogger({
   children,
 }: PropsWithChildren<ScreenLoggerProps>) {
   const headersList = headers();
-  const { device, os } = userAgent({ headers: headersList });
+  const { device, os, isBot } = userAgent({ headers: headersList });
   const $user_id = await getUserIdForServer();
   const $device_id = `${device.vendor || 'unknown'}-${device.type || undefined}-${device.model || 'unknown'}`;
   const deviceType = device.type || 'unknown';
@@ -31,7 +31,9 @@ export async function ScreenLogger({
     $os,
   };
 
-  mixpanelServer.track(eventName, properties);
+  if (!isBot) {
+    mixpanelServer.track(eventName, properties);
+  }
 
   return <>{children}</>;
 }


### PR DESCRIPTION
- Close #ISSUE_NUMBER

## What is this PR? 🔍
현재 봇들이 방문하는 경우가 이벤트에 찍히는데 봇이 아닌 경우에만 이벤트를 생성하도록 변경했습니다.
![K-001](https://github.com/user-attachments/assets/4fe792c1-98f4-4bed-8c9e-499792ab79d9)


- 기능 :
- issue : #

## Changes 📝

<!--
## ScreenShot 📷
이번 PR에서의 변경점

| Before                     | After                     |
| -------------------------- | ------------------------- |
| ![Before Image](링크_넣기) | ![After Image](링크_넣기) |
-->

## Precaution

<!-- ## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint` -->
