### PR TITLE
[FIX] 모바일 화면 default pull to refresh 차단 

### DIFF
--- a/frontend/techpick/src/app/(signed)/layout.css.ts
+++ b/frontend/techpick/src/app/(signed)/layout.css.ts
@@ -15,7 +15,3 @@ export const mobilePageContainerStyle = style({
   backgroundColor: colorVars.gold3,
   overflowY: 'auto',
 });
-
-export const mobilePreventOverscroll = style({
-  overscrollBehaviorY: 'contain',
-});

--- a/frontend/techpick/src/app/(signed)/layout.css.ts
+++ b/frontend/techpick/src/app/(signed)/layout.css.ts
@@ -17,5 +17,5 @@ export const mobilePageContainerStyle = style({
 });
 
 export const mobilePreventOverscroll = style({
-  overscrollBehaviorY: 'contain',
+  overscrollBehaviorY: 'none',
 });

--- a/frontend/techpick/src/app/(signed)/layout.css.ts
+++ b/frontend/techpick/src/app/(signed)/layout.css.ts
@@ -17,5 +17,5 @@ export const mobilePageContainerStyle = style({
 });
 
 export const mobilePreventOverscroll = style({
-  overscrollBehaviorY: 'none',
+  overscrollBehaviorY: 'contain',
 });

--- a/frontend/techpick/src/app/(signed)/layout.tsx
+++ b/frontend/techpick/src/app/(signed)/layout.tsx
@@ -13,11 +13,7 @@ import { tagKeys } from '@/queries/tagKeys';
 import { isMobileDevice } from '@/utils/isMobileDevice';
 import { HydrationBoundary, dehydrate } from '@tanstack/react-query';
 import type { PropsWithChildren } from 'react';
-import {
-  mobilePageContainerStyle,
-  mobilePreventOverscroll,
-  pageContainerLayout,
-} from './layout.css';
+import { mobilePageContainerStyle, pageContainerLayout } from './layout.css';
 
 export default async function SignedLayout({ children }: PropsWithChildren) {
   const queryClient = getQueryClient();
@@ -31,7 +27,7 @@ export default async function SignedLayout({ children }: PropsWithChildren) {
     return (
       <ScreenLogger eventName="page_view_signed_user">
         <HydrationBoundary state={dehydrate(queryClient)}>
-          <div className={mobilePreventOverscroll}>
+          <div>
             <MobileNavigationBar />
             <div className={mobilePageContainerStyle}>{children}</div>
           </div>

--- a/frontend/techpick/src/app/layout.tsx
+++ b/frontend/techpick/src/app/layout.tsx
@@ -33,8 +33,13 @@ export default async function RootLayout({
 }>) {
   const userId = await getUserIdForServer();
 
+  /**
+   * body 태그는 ThemeProvider에 존재합니다.
+   * 해당 이유는 radix의 portal이 default로 document.body에 적용되고,
+   * 해당 포탈로 생기는 영역에 테마를 주입하기 위해서입니다.
+   */
   return (
-    <html lang="en">
+    <html lang="ko">
       <UserIdentifyProvider userId={userId}>
         <ThemeProvider classname={`${notoSansKR.className}`}>
           <ToastProvider>

--- a/frontend/techpick/src/providers/ThemeProvider.tsx
+++ b/frontend/techpick/src/providers/ThemeProvider.tsx
@@ -2,6 +2,7 @@
 import { useThemeStore } from '@/stores/themeStore';
 import type { PropsWithChildren } from 'react';
 import { commonThemeClass, darkTheme, lightTheme } from 'techpick-shared';
+import { preventOverscrollBehaviorY } from './themeProvider.css';
 
 export const ThemeProvider = ({
   classname = '',
@@ -11,7 +12,9 @@ export const ThemeProvider = ({
 
   const currentTheme = isDarkMode ? darkTheme : lightTheme;
   return (
-    <body className={`${classname} ${commonThemeClass} ${currentTheme}`}>
+    <body
+      className={`${classname} ${commonThemeClass} ${currentTheme} ${preventOverscrollBehaviorY}`}
+    >
       {children}
     </body>
   );

--- a/frontend/techpick/src/providers/themeProvider.css.ts
+++ b/frontend/techpick/src/providers/themeProvider.css.ts
@@ -1,0 +1,5 @@
+import { style } from '@vanilla-extract/css';
+
+export const preventOverscrollBehaviorY = style({
+  overscrollBehaviorY: 'contain',
+});


### PR DESCRIPTION
- Close #ISSUE_NUMBER

## What is this PR? 🔍
### 추천 페이지에서 pull to refresh가 2개가 생기는 문제 수정

웹에서 제공하는 pull to refresh와 브라우저에서 제공해주는 pull to refresh가 동시에 동작합니다. 이를 수정합니다.

참고자료 - [크롬 브라우저 블로그](https://developer.chrome.com/blog/overscroll-behavior?hl=ko)

- 기능 :
- issue : #

## Changes 📝

<!--
## ScreenShot 📷
이번 PR에서의 변경점

| Before                     | After                     |
| -------------------------- | ------------------------- |
| ![Before Image](링크_넣기) | ![After Image](링크_넣기) |
-->

## Precaution

<!-- ## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint` -->
