### PR TITLE
[FIX] 모바일 화면에서 픽이 없을 때, 이미지 크기 축소

### DIFF
--- a/frontend/techpick/src/components/MobileEmptyPickRecordImage.tsx
+++ b/frontend/techpick/src/components/MobileEmptyPickRecordImage.tsx
@@ -8,7 +8,7 @@ export function MobileEmptyPickRecordImage() {
   return (
     <div className={mobileEmptyPickRecordImageStyle}>
       <div className={emptyPickListLayoutStyle}>
-        <SquirrelIcon size={'50vw'} />
+        <SquirrelIcon size={'40vw'} />
         <div>
           <p>북마크 대신 귀여운 다람쥐가 있네요! </p>
         </div>

--- a/frontend/techpick/src/components/mobileEmptyPickRecordImage.css.ts
+++ b/frontend/techpick/src/components/mobileEmptyPickRecordImage.css.ts
@@ -12,5 +12,5 @@ export const emptyPickListLayoutStyle = style({
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'center',
-  width: '80vw',
+  width: '70vw',
 });

--- a/frontend/techpick/src/components/mobileEmptyPickRecordImage.css.ts
+++ b/frontend/techpick/src/components/mobileEmptyPickRecordImage.css.ts
@@ -1,7 +1,7 @@
 import { style } from '@vanilla-extract/css';
 
 export const mobileEmptyPickRecordImageStyle = style({
-  height: 'calc(100vh - 64px)',
+  height: 'calc(100vh - 52px)',
 });
 
 export const emptyPickListLayoutStyle = style({


### PR DESCRIPTION
- Close #1086

## What is this PR? 🔍
### 스크롤이 생기기 때문에 픽이 없을 때의 이미지 크기를 축소했습니다.
- issue : #1086

https://github.com/user-attachments/assets/d4d7c6dd-242b-4e0c-8f5a-e8b2fc24eecb

## Changes 📝

<!--
## ScreenShot 📷
이번 PR에서의 변경점

| Before                     | After                     |
| -------------------------- | ------------------------- |
| ![Before Image](링크_넣기) | ![After Image](링크_넣기) |
-->

## Precaution

<!-- ## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint` -->
