### PR TITLE
[FIX] 익스텐션 북마크 추가할 때 아이콘 변경하기

### DIFF
--- a/frontend/techpick-extension/src/chrome-extension/manifest.json
+++ b/frontend/techpick-extension/src/chrome-extension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "바구니 익스텐션",
   "description": "태그와 함께 북마크하세요. 저장하고 수집한 뒤에 나중에 바구니에서 저장된 북마크를 확인해보세요!",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "icons": {
     "16": "./pick16.png",
     "32": "./pick32.png",

--- a/frontend/techpick-extension/src/components/CreatePickForm.tsx
+++ b/frontend/techpick-extension/src/components/CreatePickForm.tsx
@@ -1,4 +1,5 @@
 import { createPick } from '@/apis/createPick';
+import { CHANGE_ICON_PORT_NAME } from '@/constants/changeIconPortName';
 import { PUBLIC_DOMAIN } from '@/constants/publicDomain';
 import { useChangeFocusUsingArrowKey } from '@/hooks/useChangeFocusUsingArrowKey';
 import { useEventLogger } from '@/hooks/useEventLogger';
@@ -93,6 +94,7 @@ export function CreatePickForm({
       parentFolderId: parsedSelectedFolderId,
     })
       .then(() => {
+        chrome.runtime.connect({ name: CHANGE_ICON_PORT_NAME });
         setFolderIdToLocalhost(parsedSelectedFolderId);
         notifySuccess('추가되었습니다!');
         setTimeout(() => {

--- a/frontend/techpick-extension/src/pages/BookmarkPage.tsx
+++ b/frontend/techpick-extension/src/pages/BookmarkPage.tsx
@@ -3,7 +3,6 @@ import { getRootFolderChildFolders } from '@/apis/getRootFolderChildFolders';
 import { getTagList } from '@/apis/getTagList';
 import { CreatePickForm } from '@/components/CreatePickForm';
 import { SkeltonPickForm } from '@/components/SkeltonPickForm';
-import { CHANGE_ICON_PORT_NAME } from '@/constants/changeIconPortName';
 import { useGetFolderIdFromLocalhost } from '@/hooks/useGetFolderIdFromLocalhost';
 import { getCurrentTabInfo } from '@/libs/@chrome/getCurrentTabInfo';
 import { DeferredComponent } from '@/libs/@components/DeferredComponent';
@@ -34,7 +33,6 @@ export function BookmarkPage() {
         }
 
         const slicedTitle = title.slice(0, 255);
-        chrome.runtime.connect({ name: CHANGE_ICON_PORT_NAME });
 
         const [fetchedTagList, basicFolderList, rootFolderChildFolderList] =
           await Promise.all([


### PR DESCRIPTION
- Close #1060 

## What is this PR? 🔍
- #1060 

이전에는 아이콘을 클릭하자마자 바로 미분류로 추가되었기에 동시에 아이콘이 변경되었지만, 
현재는 버튼을 눌러야만 북마크가 추가됩니다. 따라서 북마크 버튼을 누를 때, 아이콘이 바뀌도록 변경되었습니다.

## Changes 📝

<!--
## ScreenShot 📷
이번 PR에서의 변경점

| Before                     | After                     |
| -------------------------- | ------------------------- |
| ![Before Image](링크_넣기) | ![After Image](링크_넣기) |
-->

## Precaution

<!-- ## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint` -->
