### PR TITLE
[FIX] 폴더 생성 시 인풋 포커스 추가

### DIFF
--- a/frontend/techpick/src/components/SideNavigationBar/CreateRootChildFolderInput.tsx
+++ b/frontend/techpick/src/components/SideNavigationBar/CreateRootChildFolderInput.tsx
@@ -11,7 +11,6 @@ import {
 
 export function CreateRootChildFolderInput({
   rootFolderId,
-  isShow,
   onClose,
 }: CreateRootChildFolderInputProps) {
   const { mutateAsync: createFolder } = useCreateFolder();
@@ -54,9 +53,11 @@ export function CreateRootChildFolderInput({
     [onSubmit],
   );
 
-  if (!isShow) {
-    return null;
-  }
+  useEffect(() => {
+    if (inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, []);
 
   return (
     <div ref={containerRef} className={updateFolderNameInputLayoutStyle}>
@@ -76,6 +77,5 @@ export function CreateRootChildFolderInput({
 
 interface CreateRootChildFolderInputProps {
   rootFolderId: FolderIdType;
-  isShow: boolean;
   onClose: () => void;
 }

--- a/frontend/techpick/src/components/SideNavigationBar/SideNavigationBar.tsx
+++ b/frontend/techpick/src/components/SideNavigationBar/SideNavigationBar.tsx
@@ -28,6 +28,9 @@ export function SideNavigationBar() {
     onClose,
   } = useDisclosure();
 
+  console.log('rootFolderId', rootFolderId);
+  console.log('isCreateRootChildFolder', isCreateRootChildFolder);
+
   return (
     <HorizontalResizableContainer>
       <ActiveNavigationItemIdProvider>
@@ -52,10 +55,9 @@ export function SideNavigationBar() {
             )}
           </div>
           <div className={editableFolderNavigationItemListStyle}>
-            {rootFolderId && (
+            {rootFolderId && isCreateRootChildFolder && (
               <CreateRootChildFolderInput
                 rootFolderId={rootFolderId}
-                isShow={isCreateRootChildFolder}
                 onClose={onClose}
               />
             )}

--- a/frontend/techpick/src/libs/@eventlog/ScreenLogger.tsx
+++ b/frontend/techpick/src/libs/@eventlog/ScreenLogger.tsx
@@ -8,7 +8,7 @@ import mixpanel from './mixpanel-client';
  * @param eventName 해당 이벤트의 이름입니다. snake case로 명세해주세요. ex) shared_page_view
  * @param logInfo 이벤트의 추가적인 정보를 담고 싶을 때 사용해주세요.
  */
-export async function ScreenLogger({
+export function ScreenLogger({
   eventName,
   logInfo = {},
   children,


### PR DESCRIPTION
- Close #1076 

## What is this PR? 🔍
- #1076 

이제 폴더를 클릭했을 때 자동으로 인풋에 포커스가 이동됩니다.

## Changes 📝

<!--
## ScreenShot 📷
이번 PR에서의 변경점

| Before                     | After                     |
| -------------------------- | ------------------------- |
| ![Before Image](링크_넣기) | ![After Image](링크_넣기) |
-->

## Precaution

<!-- ## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint` -->
