### PR TITLE
[FIX] og image 출력방식 변경

### DIFF
--- a/frontend/techpick/src/app/(unsigned)/share/[uuid]/opengraph-image.tsx
+++ b/frontend/techpick/src/app/(unsigned)/share/[uuid]/opengraph-image.tsx
@@ -1,0 +1,92 @@
+import { getShareFolderById } from '@/apis/folder/getShareFolderById';
+import { ImageResponse } from 'next/og';
+
+export const alt = '공유 폴더 미리보기';
+export const size = {
+  width: 1200,
+  height: 630,
+};
+
+const styles = {
+  1: { width: '1200px', height: '630px' },
+  2: { width: '600px', height: '630px' },
+  4: { width: '600px', height: '315px' },
+  8: { width: '300px', height: '315px' },
+  16: { width: '300px', height: '157.5px' },
+};
+
+const getImageStyle = (index: number) => {
+  return styles[index as keyof typeof styles] || styles[16];
+};
+
+export const contentType = 'image/png';
+
+async function testImageUrl(url: string): Promise<boolean> {
+  try {
+    const res = await fetch(url, { method: 'HEAD' });
+    return (
+      res.ok && (res.headers.get('Content-Type')?.startsWith('image/') ?? false)
+    );
+  } catch {
+    return false;
+  }
+}
+
+export default async function Image({ params }: { params: { uuid: string } }) {
+  const { uuid } = params;
+  const sharedFolder = await getShareFolderById(uuid);
+  const { pickList } = sharedFolder;
+
+  const imageUrls = await Promise.all(
+    pickList
+      .map((pick) => pick.linkInfo.imageUrl)
+      .filter((url) => url && url !== '')
+      .slice(0, 16)
+      .map(async (url) => {
+        if (!(typeof url === 'string')) {
+          return null;
+        }
+
+        const isValid = await testImageUrl(url);
+        return isValid ? url : null;
+      }),
+  );
+  let ogImageUrls = imageUrls.filter((url) => typeof url === 'string');
+
+  const imageCount = [1, 2, 4, 8, 16].reduce((prev, curr) =>
+    Math.abs(curr - ogImageUrls.length) < Math.abs(prev - ogImageUrls.length)
+      ? curr
+      : prev,
+  );
+  ogImageUrls = ogImageUrls.slice(0, imageCount);
+
+  if (ogImageUrls.length === 0) {
+    return <img src="/image/og_image.png" alt={alt} />;
+  }
+
+  return new ImageResponse(
+    <div
+      style={{
+        display: 'flex',
+        flexWrap: 'wrap',
+        width: '1200px',
+        height: '630px',
+      }}
+    >
+      {ogImageUrls.map((url: string, index: number) => (
+        <img
+          // biome-ignore lint/a11y/noRedundantAlt: <explanation>
+          alt="open graph image"
+          // biome-ignore lint/suspicious/noArrayIndexKey: <explanation>
+          key={index}
+          src={url}
+          style={{
+            ...getImageStyle(imageCount),
+            objectFit: 'cover',
+          }}
+        />
+      ))}
+    </div>,
+    { ...size },
+  );
+}

--- a/frontend/techpick/src/app/(unsigned)/share/[uuid]/page.tsx
+++ b/frontend/techpick/src/app/(unsigned)/share/[uuid]/page.tsx
@@ -8,7 +8,7 @@ import { ROUTES } from '@/constants/route';
 import { ScreenLogger } from '@/libs/@eventlog/ScreenLogger';
 import { isLoginUser } from '@/utils/isLoginUser';
 import { FolderOpenIcon } from 'lucide-react';
-import type { Metadata, ResolvingMetadata } from 'next';
+import type { Metadata } from 'next';
 import dynamic from 'next/dynamic';
 import Link from 'next/link';
 import { LandingPageLinkButton } from './LandingPageLinkButton';
@@ -35,49 +35,18 @@ const EmptyPickRecordImage = dynamic(
   },
 );
 
-// TODO:
-// 해당 코드는 api를 쓰는 방식이 아닌,
-// https://nextjs.org/docs/14/app/api-reference/file-conventions/metadata/opengraph-image#generate-images-using-code-js-ts-tsx
-// 에서 나오는 방식으로 변경해야합니다.
-export async function generateMetadata(
-  {
-    params,
-  }: {
-    params: { uuid: string };
-  },
-  parent: ResolvingMetadata,
-): Promise<Metadata> {
+export async function generateMetadata({
+  params,
+}: { params: { uuid: string } }): Promise<Metadata> {
   const { uuid } = params;
   const sharedFolder = await getShareFolderById(uuid);
-  const { pickList } = sharedFolder;
+  const { folderName, pickList } = sharedFolder;
 
-  const imageUrls = pickList
-    .map((pick) => pick.linkInfo.imageUrl)
-    .filter((url) => url && url !== '')
-    .slice(0, 16); // 최대 16개까지 허용
-
-  let ogImageUrl: string;
-
-  if (imageUrls.length === 0) {
-    ogImageUrl = '/image/og_image.png';
-  } else {
-    const apiUrl = new URL(
-      `${process.env.NEXT_PUBLIC_IMAGE_URL}/api/generate-og-image`,
-    );
-    apiUrl.searchParams.set('imageUrls', JSON.stringify(imageUrls));
-    ogImageUrl = apiUrl.toString();
-  }
-
-  const previousImages = (await parent).openGraph?.images || [];
   return {
-    title: `${sharedFolder.folderName} 폴더 공유 페이지`,
-    description: `${pickList.length}개의 북마크가 공유되었습니다.`,
-    openGraph: {
-      images: [ogImageUrl, ...previousImages],
-    },
+    title: `${folderName} 공유 폴더`,
+    description: `${pickList.length}개의 북마크를 확인해보세요!`,
   };
 }
-
 export default async function Page({ params }: { params: { uuid: string } }) {
   const { uuid } = params;
   const sharedFolder = await getShareFolderById(uuid);


### PR DESCRIPTION
- Close #ISSUE_NUMBER

## What is this PR? 🔍
### OG image를 API가 아닌 `opengraph-image.tsx`에서 제공하도록 변경했습니다.
- issue : #1077

local에서 테스트할 수 없어서 개발 서버에 배포된 후에 테스트 진행해보겠습니다.

## Changes 📝

<!--
## ScreenShot 📷
이번 PR에서의 변경점

| Before                     | After                     |
| -------------------------- | ------------------------- |
| ![Before Image](링크_넣기) | ![After Image](링크_넣기) |
-->

## Precaution

<!-- ## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint` -->
