### PR TITLE
[FIX] og image 생성 로직 변경

### DIFF
--- a/frontend/techpick/src/app/api/generate-og-image/route.tsx
+++ b/frontend/techpick/src/app/api/generate-og-image/route.tsx
@@ -57,12 +57,28 @@ export async function GET(req: NextRequest) {
       ),
     );
     const filteredImageUrls = validImageUrls.filter((url) => url !== null);
-    const adjustedCount = [1, 2, 4, 8, 16].reduce((prev, curr) =>
-      Math.abs(curr - filteredImageUrls.length) <
-      Math.abs(prev - filteredImageUrls.length)
-        ? curr
-        : prev,
-    );
+
+    if (filteredImageUrls.length === 0) {
+      return <img src="/image/og_image.png" alt="" />;
+    }
+
+    let adjustedCount = 1;
+
+    switch (true) {
+      case filteredImageUrls.length >= 16:
+        adjustedCount = 16;
+        break;
+      case filteredImageUrls.length >= 8:
+        adjustedCount = 8;
+        break;
+      case filteredImageUrls.length >= 4:
+        adjustedCount = 4;
+        break;
+      case filteredImageUrls.length >= 2:
+        adjustedCount = 2;
+        break;
+    }
+
     images = filteredImageUrls.slice(0, adjustedCount);
     imageCount = images.length;
   } catch {


### PR DESCRIPTION
- Close #1103 

## What is this PR? 🔍
### og image 생성 로직 변경
- #1103 

![generate-og-image](https://github.com/user-attachments/assets/6fee6bdf-d9dc-4011-b2c5-a5db55053451)
이렇게 비어있는 이미지가 만들어졌었는데 로직에서 문제점이 있었습니다. 이를 수정했습니다.

![generate-og-image (1)](https://github.com/user-attachments/assets/e2b78934-a805-4d87-a80b-12eacde96bba)



## Changes 📝

<!--
## ScreenShot 📷
이번 PR에서의 변경점

| Before                     | After                     |
| -------------------------- | ------------------------- |
| ![Before Image](링크_넣기) | ![After Image](링크_넣기) |
-->

## Precaution

<!-- ## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint` -->
