### PR TITLE
[FEAT] 공유 중 버튼을 누르면 공유 폴더 페이지로 이동

### DIFF
--- a/frontend/techpick/src/components/FolderContentHeader/CurrentFolderNameSection.tsx
+++ b/frontend/techpick/src/components/FolderContentHeader/CurrentFolderNameSection.tsx
@@ -1,12 +1,14 @@
 'use client';
 
+import { ROUTES } from '@/constants/route';
 import type { FolderType } from '@/types/FolderType';
 import { FolderOpenIcon } from 'lucide-react';
+import Link from 'next/link';
 import {
   currentFolderNameSectionStyle,
   folderNameStyle,
   folderOpenIconStyle,
-  folderSharedInfoTextStyle,
+  folderSharedInfoLinkStyle,
 } from './currentFolderNameSection.css';
 
 export function CurrentFolderNameSection({
@@ -20,9 +22,13 @@ export function CurrentFolderNameSection({
       </h1>
 
       {folderInfo?.folderAccessToken ? (
-        <div className={folderSharedInfoTextStyle}>
-          <div>(공유 중)</div>
-        </div>
+        <Link
+          href={ROUTES.SHARE(folderInfo.folderAccessToken)}
+          className={folderSharedInfoLinkStyle}
+          target="_blank"
+        >
+          (공유 중)
+        </Link>
       ) : null}
     </div>
   );

--- a/frontend/techpick/src/components/FolderContentHeader/FolderContentHeader.tsx
+++ b/frontend/techpick/src/components/FolderContentHeader/FolderContentHeader.tsx
@@ -5,11 +5,11 @@ import type { FolderIdType } from '@/types/FolderIdType';
 import { getBasicFolderInfoByFolderId } from '@/utils/getBasicFolderInfoByFolderId';
 import { getFolderInfoByFolderId } from '@/utils/getFolderInfoByFolderId';
 import { ChromeExtensionLinkButton } from '../ChromeExtensionLinkButton/ChromeExtensionLinkButton';
-import { Gap } from '../Gap';
 import { CurrentFolderNameSection } from './CurrentFolderNameSection';
 import { CurrentPathIndicator } from './CurrentPathIndicator';
 import {
   createPickPopoverButtonLayoutStyle,
+  currentPathIndicatorLayoutStyle,
   folderContentHeaderLayoutStyle,
   folderContentHeaderStyle,
   folderDescriptionStyle,
@@ -26,22 +26,19 @@ export function FolderContentHeader({ folderId }: FolderContentHeaderProps) {
 
   return (
     <div className={folderContentHeaderLayoutStyle}>
-      <Gap verticalSize="gap16" horizontalSize="gap24">
-        <div className={folderContentHeaderStyle}>
-          <div className={folderDescriptionStyle}>
-            <CurrentFolderNameSection folderInfo={folderInfo} />
-            <Gap verticalSize="gap4">
-              <CurrentPathIndicator folderInfo={folderInfo} />
-            </Gap>
-          </div>
-
-          <div className={createPickPopoverButtonLayoutStyle}>
-            {folderInfo?.folderType !== 'RECYCLE_BIN' && (
-              <ChromeExtensionLinkButton />
-            )}
+      <div className={folderContentHeaderStyle}>
+        <div className={folderDescriptionStyle}>
+          <CurrentFolderNameSection folderInfo={folderInfo} />
+          <div className={currentPathIndicatorLayoutStyle}>
+            <CurrentPathIndicator folderInfo={folderInfo} />
           </div>
         </div>
-      </Gap>
+        <div className={createPickPopoverButtonLayoutStyle}>
+          {folderInfo?.folderType !== 'RECYCLE_BIN' && (
+            <ChromeExtensionLinkButton />
+          )}
+        </div>
+      </div>
     </div>
   );
 }

--- a/frontend/techpick/src/components/FolderContentHeader/currentFolderNameSection.css.ts
+++ b/frontend/techpick/src/components/FolderContentHeader/currentFolderNameSection.css.ts
@@ -1,5 +1,6 @@
+import { orangeGhostButtonStyle } from '@/styles/orangeButtonStyle.css';
 import { style } from '@vanilla-extract/css';
-import { colorVars, fontWeights } from 'techpick-shared';
+import { fontWeights } from 'techpick-shared';
 
 export const currentFolderNameSectionStyle = style({
   display: 'inline-flex',
@@ -27,10 +28,13 @@ export const folderNameStyle = style({
   overflow: 'hidden',
 });
 
-export const folderSharedInfoTextStyle = style({
-  flexShrink: '0',
-  width: '80px',
-  fontSize: '12px',
-  fontWeight: '600',
-  color: colorVars.primary,
-});
+export const folderSharedInfoLinkStyle = style([
+  {
+    display: 'flex',
+    justifyContent: 'center',
+    flexShrink: '0',
+    width: '60px',
+    fontSize: '12px',
+  },
+  orangeGhostButtonStyle,
+]);

--- a/frontend/techpick/src/components/FolderContentHeader/folderContentHeader.css.ts
+++ b/frontend/techpick/src/components/FolderContentHeader/folderContentHeader.css.ts
@@ -18,8 +18,13 @@ export const createPickPopoverButtonLayoutStyle = style({
 export const folderContentHeaderStyle = style({
   display: 'flex',
   justifyContent: 'space-between',
+  padding: '8px 12px',
 });
 
 export const folderDescriptionStyle = style({
   minWidth: '0',
+});
+
+export const currentPathIndicatorLayoutStyle = style({
+  padding: '2px 0',
 });

--- a/frontend/techpick/src/constants/route.ts
+++ b/frontend/techpick/src/constants/route.ts
@@ -6,4 +6,5 @@ export const ROUTES = {
   LOGIN: '/login',
   MY_PAGE: '/mypage',
   LANDING: '/landing',
+  SHARE: (uuid: string) => `/share/${uuid}`,
 };


### PR DESCRIPTION
- Close #1027 

## What is this PR? 🔍
### 폴더 페이지에서 공유중이라면 공유 폴더 페이지로 이동할 수 있게 변경했습니다
- #1027 

공유중인 폴더라면 아래의 `공유 중` 버튼을 눌러 공유 폴더로 이동할 수 있습니다.
![K-002](https://github.com/user-attachments/assets/14010108-d0c1-486e-8ed7-83be7e6bcdd7)

이전까지의 마이페이지에서 이동하여 공유 폴더를 찾아야하는 번거로운 과정을 생략할 수 있습니다.


## Changes 📝

<!--
## ScreenShot 📷
이번 PR에서의 변경점

| Before                     | After                     |
| -------------------------- | ------------------------- |
| ![Before Image](링크_넣기) | ![After Image](링크_넣기) |
-->

## Precaution

<!-- ## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint` -->
