### PR TITLE
[REFACTOR] 메시지 소비 로그 메시지 변경

### DIFF
--- a/backend/baguni-batch/src/main/java/baguni/batch/domain/link/service/LinkUpdateEventListener.java
+++ b/backend/baguni-batch/src/main/java/baguni/batch/domain/link/service/LinkUpdateEventListener.java
@@ -36,21 +36,21 @@ public class LinkUpdateEventListener {
 
 	@RabbitHandler
 	public void consumeMessage(LinkCreateEvent ev) {
-		log.info("메시지 dequeue : topic {}, url {}", ev.getTopicString(), ev);
+		log.info("메시지 소비: topic {}, url {}", ev.getTopicString(), ev.getUrl());
 		LinkResult link = linkService.getLinkResultByUrl(ev.getUrl());
 		doLinkUpdate(link);
 	}
 
 	@RabbitHandler
 	public void consumeMessage(LinkReadEvent ev) {
-		log.info("메시지 dequeue : topic {}, url {}", ev.getTopicString(), ev);
+		log.info("메시지 소비: topic {}, url {}", ev.getTopicString(), ev.getUrl());
 		LinkResult link = linkService.getLinkResultByUrl(ev.getUrl());
 		doLinkUpdate(link);
 	}
 
 	@RabbitHandler
 	public void consumeMessage(BookmarkCreateEvent ev) {
-		log.info("메시지 dequeue : topic {}, url {}", ev.getTopicString(), ev);
+		log.info("메시지 소비: topic {}, url {}", ev.getTopicString(), ev.getUrl());
 		LinkResult link = linkService.getLinkResultByUrl(ev.getUrl());
 		doLinkUpdate(link);
 	}

--- a/backend/baguni-ranking/src/main/java/baguni/ranking/infra/RankingEventListener.java
+++ b/backend/baguni-ranking/src/main/java/baguni/ranking/infra/RankingEventListener.java
@@ -35,7 +35,7 @@ public class RankingEventListener {
 	 */
 	@RabbitHandler
 	public void bookmarkCreateEvent(BookmarkCreateEvent event) {
-		log.info("북마크 생성 이벤트 수신 {}", event);
+		log.info("메시지 소비: topic {}, url {}", event.getTopicString(), event.getUrl());
 		var date = event.getTime().toLocalDate();
 		var url = event.getUrl();
 		updateLinkPickedCount(date, url);
@@ -46,7 +46,7 @@ public class RankingEventListener {
 	 */
 	@RabbitHandler
 	public void linkReadEvent(LinkReadEvent event) {
-		log.info("링크 조회 이벤트 수신 {}", event);
+		log.info("메시지 소비: topic {}, url {}", event.getTopicString(), event.getUrl());
 		var date = event.getTime().toLocalDate();
 		var url = event.getUrl();
 		updateLinkViewCount(date, url);


### PR DESCRIPTION
## What is this PR? 🔍

- 기능 : 메시지 소비 관련 로그 통일
- 랭킹 서버와 배치 서버의 로그를 통일 + url을 로그에서 출력하도록 수정
![image](https://github.com/user-attachments/assets/a4a74ae3-77f6-48b2-a105-056f75614013)
위 이미지를 보면 각 소비 메시지가 다르고, url이 출력되지 않음. 이 부분 통일함.


