### PR TITLE
[FIX] 에러 로그 메시지 레벨 복구

### DIFF
--- a/backend/baguni-common/src/main/java/baguni/common/exception/level/ErrorLevel.java
+++ b/backend/baguni-common/src/main/java/baguni/common/exception/level/ErrorLevel.java
@@ -30,8 +30,14 @@ public abstract class ErrorLevel {
 		return new FatalErrorLevel();
 	}
 
+	/**
+	 * @deprecated 필터에서 로그를 남기고 삭제할 예정
+	 */
 	public abstract void logByLevel(Exception exception, CachedHttpServletRequest request);
 
+	/**
+	 * @deprecated 필터에서 로그를 남기고 삭제할 예정 (슬랙 알림 대시보드 클릭시 바로 묶어서 볼 수 있게 변경)
+	 */
 	public abstract void logByLevel(Exception exception, String requestURI, String requestMethod);
 
 	public abstract void logByLevel(Exception exception);

--- a/backend/baguni-common/src/main/java/baguni/common/exception/level/FatalErrorLevel.java
+++ b/backend/baguni-common/src/main/java/baguni/common/exception/level/FatalErrorLevel.java
@@ -6,6 +6,9 @@ import baguni.common.util.CachedHttpServletRequest;
 @Slf4j
 public class FatalErrorLevel extends ErrorLevel {
 
+	/**
+	 * @deprecated 필터에서 로그를 남기고 삭제할 예정
+	 */
 	@Override
 	public void logByLevel(Exception exception, CachedHttpServletRequest request) {
 		log.error(
@@ -15,6 +18,9 @@ public class FatalErrorLevel extends ErrorLevel {
 		);
 	}
 
+	/**
+	 * @deprecated 필터에서 로그를 남기고 삭제할 예정
+	 */
 	@Override
 	public void logByLevel(Exception exception, String requestURI, String requestMethod) {
 		log.error(

--- a/backend/baguni-common/src/main/java/baguni/common/exception/level/FatalErrorLevel.java
+++ b/backend/baguni-common/src/main/java/baguni/common/exception/level/FatalErrorLevel.java
@@ -8,7 +8,11 @@ public class FatalErrorLevel extends ErrorLevel {
 
 	@Override
 	public void logByLevel(Exception exception, CachedHttpServletRequest request) {
-		log.error("{}{}", exception.getMessage(), request, exception); // stack trace 출력
+		log.error(
+			"{}{}",
+			exception.getMessage(), request,
+			exception // stack trace 출력
+		);
 	}
 
 	@Override

--- a/backend/baguni-common/src/main/java/baguni/common/exception/level/NormalErrorLevel.java
+++ b/backend/baguni-common/src/main/java/baguni/common/exception/level/NormalErrorLevel.java
@@ -6,6 +6,9 @@ import baguni.common.util.CachedHttpServletRequest;
 @Slf4j
 public class NormalErrorLevel extends ErrorLevel {
 
+	/**
+	 * @deprecated 필터에서 로그를 남기고 삭제할 예정
+	 */
 	@Override
 	public void logByLevel(Exception exception, CachedHttpServletRequest request) {
 		log.info(
@@ -14,6 +17,9 @@ public class NormalErrorLevel extends ErrorLevel {
 		);
 	}
 
+	/**
+	 * @deprecated 필터에서 로그를 남기고 삭제할 예정 (슬랙 알림 대시보드 클릭시 바로 묶어서 볼 수 있게 변경)
+	 */
 	@Override
 	public void logByLevel(Exception exception, String requestURI, String requestMethod) {
 		log.info(

--- a/backend/baguni-common/src/main/java/baguni/common/exception/level/NormalErrorLevel.java
+++ b/backend/baguni-common/src/main/java/baguni/common/exception/level/NormalErrorLevel.java
@@ -8,28 +8,25 @@ public class NormalErrorLevel extends ErrorLevel {
 
 	@Override
 	public void logByLevel(Exception exception, CachedHttpServletRequest request) {
-		// TODO: 에러 알림 작업 끝나면 복구
-		// log.info("{}{}", exception.getMessage(), request); // stack trace 미출력
-		log.error("{}{}", exception.getMessage(), request, exception); // stack trace 출력
+		log.info(
+			"{}{}",
+			exception.getMessage(), request
+		);
 	}
 
 	@Override
 	public void logByLevel(Exception exception, String requestURI, String requestMethod) {
-		// TODO: 에러 알림 작업 끝나면 복구
-		log.error(
+		log.info(
 			"{} requestURI={} requestMethod={}",
-			exception.getMessage(), requestURI, requestMethod,
-			exception // stack trace 출력
+			exception.getMessage(), requestURI, requestMethod
 		);
 	}
 
 	@Override
 	public void logByLevel(Exception exception) {
-		// TODO: 에러 알림 작업 끝나면 복구
-		log.error(
+		log.info(
 			"{}",
-			exception.getMessage(),
-			exception // stack trace 출력
+			exception.getMessage()
 		);
 	}
 }

--- a/backend/baguni-common/src/main/java/baguni/common/exception/level/WarningErrorLevel.java
+++ b/backend/baguni-common/src/main/java/baguni/common/exception/level/WarningErrorLevel.java
@@ -6,6 +6,9 @@ import baguni.common.util.CachedHttpServletRequest;
 @Slf4j
 public class WarningErrorLevel extends ErrorLevel {
 
+	/**
+	 * @deprecated 필터에서 로그를 남기고 삭제할 예정
+	 */
 	@Override
 	public void logByLevel(Exception exception, CachedHttpServletRequest request) {
 		log.warn(
@@ -14,6 +17,9 @@ public class WarningErrorLevel extends ErrorLevel {
 		);
 	}
 
+	/**
+	 * @deprecated 필터에서 로그를 남기고 삭제할 예정 (슬랙 알림 대시보드 클릭시 바로 묶어서 볼 수 있게 변경)
+	 */
 	@Override
 	public void logByLevel(Exception exception, String requestURI, String requestMethod) {
 		log.warn(

--- a/backend/baguni-common/src/main/java/baguni/common/exception/level/WarningErrorLevel.java
+++ b/backend/baguni-common/src/main/java/baguni/common/exception/level/WarningErrorLevel.java
@@ -8,15 +8,17 @@ public class WarningErrorLevel extends ErrorLevel {
 
 	@Override
 	public void logByLevel(Exception exception, CachedHttpServletRequest request) {
-		log.warn("{}{}", exception.getMessage(), request); // stack trace 미출력
+		log.warn(
+			"{}{}",
+			exception.getMessage(), request
+		);
 	}
 
 	@Override
 	public void logByLevel(Exception exception, String requestURI, String requestMethod) {
 		log.warn(
 			"{} requestURI={} requestMethod={}",
-			exception.getMessage(), requestURI, requestMethod,
-			exception // stack trace 출력
+			exception.getMessage(), requestURI, requestMethod
 		);
 	}
 
@@ -24,8 +26,7 @@ public class WarningErrorLevel extends ErrorLevel {
 	public void logByLevel(Exception exception) {
 		log.warn(
 			"{}",
-			exception.getMessage(),
-			exception // stack trace 출력
+			exception.getMessage()
 		);
 	}
 }

--- a/backend/baguni-common/src/main/java/baguni/common/util/CachedHttpServletRequest.java
+++ b/backend/baguni-common/src/main/java/baguni/common/util/CachedHttpServletRequest.java
@@ -41,6 +41,18 @@ public class CachedHttpServletRequest extends HttpServletRequestWrapper {
 		}
 	}
 
+	public String getRequestBody() {
+		return infoMap.get("requestBody").toString();
+	}
+
+	public String getRequestMethod() {
+		return infoMap.get("method").toString();
+	}
+
+	public String getRequestURI() {
+		return infoMap.get("requestURI").toString();
+	}
+
 	public CachedHttpServletRequest(HttpServletRequest request) throws IOException {
 		super(request);
 

--- a/backend/baguni-common/src/main/java/baguni/common/util/RequestLoggingFilter.java
+++ b/backend/baguni-common/src/main/java/baguni/common/util/RequestLoggingFilter.java
@@ -37,11 +37,7 @@ public class RequestLoggingFilter extends OncePerRequestFilter {
 			CachedHttpServletRequest cachedRequest = new CachedHttpServletRequest(request);
 
 			// TODO: 아래 로그로 남기고, Thread Local에 저장하는 Request Holder를 제거.
-			log.info(
-				"{} {} {} {}",
-				cachedRequest.getMethod(), cachedRequest.getRequestURI(), cachedRequest.getQueryString(),
-				cachedRequest.getRequestBody()
-			);
+			log.info("{}", request);
 
 			// TODO: 아래 부분 + try catch 삭제
 			requestHolder.setRequest(cachedRequest);


### PR DESCRIPTION
- Close #1116

1. 그라파나 에러 알림 작업이 끝남에 따라 
    에러 레벨을 다시 원상복구합니다.

2. 토의 후 삭제될 부분에 대해 주석을 남겼고, 
    Request 시작시 해당 정보를 기록하는 로그를 추가했습니다.