### PR TITLE
[FEAT] 센트리 개발 환경에서는 에러 전송하지 않게 변경

### DIFF
--- a/frontend/techpick/sentry.client.config.ts
+++ b/frontend/techpick/sentry.client.config.ts
@@ -7,6 +7,13 @@ import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
   dsn: 'https://ccec74582beec7789ae87df0139c6c48@o4508448586465280.ingest.us.sentry.io/4508520962916352',
+  beforeSend(event) {
+    // 개발 환경에서는 이벤트를 전송하지 않음
+    if (process.env.NODE_ENV === 'development') {
+      return null;
+    }
+    return event;
+  },
 
   // Add optional integrations for additional features
   integrations: [
@@ -23,19 +30,18 @@ Sentry.init({
   ],
 
   // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-  tracesSampleRate: 1,
+  tracesSampleRate: process.env.NODE_ENV === 'development' ? 0 : 1,
 
   // Define how likely Replay events are sampled.
   // This sets the sample rate to be 10%. You may want this to be 100% while
   // in development and sample at a lower rate in production
-  replaysSessionSampleRate: 0.1,
-
+  replaysSessionSampleRate: process.env.NODE_ENV === 'development' ? 0 : 0.1,
   /**
    * 에러가 발생할 때 즉시 녹화가 시작되어 지속되는 리플레이 샘플 속도입니다.
    * 오류 전 최대 1분동안 이벤트를 기록합니다.
    * 1.0 - 0 사이의 값을 사용합니다. (1.0 권장)
    */
-  replaysOnErrorSampleRate: 1.0,
+  replaysOnErrorSampleRate: process.env.NODE_ENV === 'development' ? 0 : 1.0,
 
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,

--- a/frontend/techpick/sentry.edge.config.ts
+++ b/frontend/techpick/sentry.edge.config.ts
@@ -9,7 +9,7 @@ Sentry.init({
   dsn: 'https://ccec74582beec7789ae87df0139c6c48@o4508448586465280.ingest.us.sentry.io/4508520962916352',
 
   // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-  tracesSampleRate: 1,
+  tracesSampleRate: process.env.NODE_ENV === 'development' ? 0 : 1,
 
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,

--- a/frontend/techpick/sentry.server.config.ts
+++ b/frontend/techpick/sentry.server.config.ts
@@ -8,7 +8,7 @@ Sentry.init({
   dsn: 'https://ccec74582beec7789ae87df0139c6c48@o4508448586465280.ingest.us.sentry.io/4508520962916352',
 
   // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-  tracesSampleRate: 1,
+  tracesSampleRate: process.env.NODE_ENV === 'development' ? 0 : 1,
 
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,

--- a/frontend/techpick/src/apis/apiClient.ts
+++ b/frontend/techpick/src/apis/apiClient.ts
@@ -34,11 +34,15 @@ export const apiClient = ky.create({
             url: httpError.request.url,
             method: httpError.request.method,
           });
-          Sentry.captureException(error);
+
           const parsedErrorMessage = error.message.split(' ');
           const errorCode = parsedErrorMessage.shift();
 
           if (errorCode && ERROR_MESSAGE_JSON[errorCode]) {
+            if (errorCode === 'UNKNOWN') {
+              Sentry.captureMessage('500 서버 에러', 'error');
+            }
+
             if (errorCode === 'AU-001') {
               if (isServer) {
                 redirect('/login');


### PR DESCRIPTION
- Close #1051 

## What is this PR? 🔍
### 센트리 설정을 변경했습니다.
- #1051 

이제 로컬 개발 환경에서 발생하는 에러는 송신하지 않습니다.
또한 모든 에러가 아닌 예측하지 못한 에러와, 500번 서버 에러만 발생됩니다.



## Changes 📝

<!--
## ScreenShot 📷
이번 PR에서의 변경점

| Before                     | After                     |
| -------------------------- | ------------------------- |
| ![Before Image](링크_넣기) | ![After Image](링크_넣기) |
-->

## Precaution

<!-- ## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint` -->
