### PR TITLE
[FIX] 바깥 영역을 누를 때 폴더 인풋이 닫히게 변경

### DIFF
--- a/frontend/techpick/src/components/SideNavigationBar/CreateChildFolderInput.tsx
+++ b/frontend/techpick/src/components/SideNavigationBar/CreateChildFolderInput.tsx
@@ -53,6 +53,7 @@ export function CreateChildFolderInput({
           !containerRef.current.contains(event.target as Node)
         ) {
           onSubmit();
+          onCloseCreateFolderInput();
         }
       };
 
@@ -61,7 +62,7 @@ export function CreateChildFolderInput({
         document.removeEventListener('mousedown', handleClickOutside);
       };
     },
-    [onSubmit],
+    [onSubmit, onCloseCreateFolderInput],
   );
 
   if (!isCreateChildFolderOpen) {

--- a/frontend/techpick/src/components/SideNavigationBar/CreateRootChildFolderInput.tsx
+++ b/frontend/techpick/src/components/SideNavigationBar/CreateRootChildFolderInput.tsx
@@ -42,6 +42,7 @@ export function CreateRootChildFolderInput({
           !containerRef.current.contains(event.target as Node)
         ) {
           onSubmit();
+          onClose();
         }
       };
 
@@ -50,7 +51,7 @@ export function CreateRootChildFolderInput({
         document.removeEventListener('mousedown', handleClickOutside);
       };
     },
-    [onSubmit],
+    [onSubmit, onClose],
   );
 
   useEffect(() => {


### PR DESCRIPTION
- Close #1131

## What is this PR? 🔍
### 다른 영역을 누를 때 폴더 인풋이 닫히게 변경
- #1131 

빈 값일 때, 닫히지 않는 버그가 있어서 수정했습니다.

## Changes 📝

<!--
## ScreenShot 📷
이번 PR에서의 변경점

| Before                     | After                     |
| -------------------------- | ------------------------- |
| ![Before Image](링크_넣기) | ![After Image](링크_넣기) |
-->

## Precaution

<!-- ## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint` -->
