### PR TITLE
[FIX] 공유 폴더 모바일 화면 모두 보이는 문제 수정

### DIFF
--- a/frontend/techpick/src/app/(unsigned)/share/[uuid]/MobileSharedPickRecord.tsx
+++ b/frontend/techpick/src/app/(unsigned)/share/[uuid]/MobileSharedPickRecord.tsx
@@ -23,7 +23,14 @@ export function MobileSharedPickRecord({
   const link = pickInfo.linkInfo;
   const { openUrlInNewTab } = useOpenUrlInNewTab(link.url);
   const { imageStatus } = useImageLoader(link.imageUrl);
-  const filteredSelectedTagList = tagList.slice(0, 5);
+  const filteredSelectedTagList = pickInfo.tagIdxList
+    ?.map((tagIdx) => {
+      if (tagList[tagIdx]) {
+        return tagList[tagIdx];
+      }
+    })
+    .filter((value) => value !== undefined)
+    .slice(0, 5);
 
   const onClickLink = async () => {
     try {


### PR DESCRIPTION
- Close #ISSUE_NUMBER

## What is this PR? 🔍
### 공유폴더의 모바일 화면에서 모든 태그가 보여지는 문제가 있었습니다. 이를 수정했습니다.
![KakaoTalk_20250220_182716842](https://github.com/user-attachments/assets/75c2c7e5-1ef7-4f85-8c9f-43fecc4ba621)

- 기능 :
- issue : #

## Changes 📝

<!--
## ScreenShot 📷
이번 PR에서의 변경점

| Before                     | After                     |
| -------------------------- | ------------------------- |
| ![Before Image](링크_넣기) | ![After Image](링크_넣기) |
-->

## Precaution

<!-- ## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint` -->
