### PR TITLE
[FEAT] 배치 서버에 랭킹 집계 기능 추가

### DIFF
--- a/backend/baguni-batch/src/main/java/baguni/batch/listener/LinkRankingEventListener.java
+++ b/backend/baguni-batch/src/main/java/baguni/batch/listener/LinkRankingEventListener.java
@@ -1,0 +1,61 @@
+package baguni.batch.listener;
+
+import org.springframework.amqp.rabbit.annotation.RabbitHandler;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Component;
+
+import baguni.common.config.RabbitmqConfig;
+import baguni.common.event.events.BookmarkCreateEvent;
+import baguni.common.event.events.LinkReadEvent;
+import baguni.domain.infrastructure.link.LinkStatsRepository;
+import baguni.domain.model.link.LinkStats;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * RabbitMq Queue(PICK_RANKING) 에 들어오는 대로
+ * 즉시 꺼내 집계에 반영하는 소비자 컴포넌트
+ * */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@RabbitListener(queues = {RabbitmqConfig.QUEUE.LINK_RANKING_V2})
+public class LinkRankingEventListener {
+
+	// TODO: LinkDataHandler를 써야 하나?
+	private final LinkStatsRepository linkStatsRepository;
+
+	@RabbitHandler
+	public void updateViewCount(LinkReadEvent event) {
+		log.info("메시지 소비: topic {}, url {}", event.getTopicString(), event.getUrl());
+		var date = event.getTime().toLocalDate();
+		var url = event.getUrl();
+		var linkStats = linkStatsRepository
+			.findByDateAndUrl(date, url)
+			.orElseGet(() -> new LinkStats(date, url));
+
+		linkStats.incrementViewCount();
+		linkStatsRepository.save(linkStats);
+	}
+
+	@RabbitHandler
+	public void updateBookmarkedCount(BookmarkCreateEvent event) {
+		log.info("메시지 소비: topic {}, url {}", event.getTopicString(), event.getUrl());
+		var date = event.getTime().toLocalDate();
+		var url = event.getUrl();
+		var linkStats = linkStatsRepository
+			.findByDateAndUrl(date, url)
+			.orElseGet(() -> new LinkStats(date, url));
+
+		linkStats.incrementBookmarkedCount();
+		linkStatsRepository.save(linkStats);
+	}
+
+	/**
+	 * 매핑되지 않은 이벤트
+	 */
+	@RabbitHandler(isDefault = true)
+	public void defaultMethod(Object object) {
+		log.error("일치하는 이벤트 타입이 없습니다! {}", object.toString());
+	}
+}

--- a/backend/baguni-batch/src/main/java/baguni/batch/listener/LinkUpdateEventListener.java
+++ b/backend/baguni-batch/src/main/java/baguni/batch/listener/LinkUpdateEventListener.java
@@ -1,4 +1,4 @@
-package baguni.batch.domain.link.service;
+package baguni.batch.listener;
 
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
@@ -8,6 +8,7 @@ import org.springframework.amqp.rabbit.annotation.RabbitHandler;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.stereotype.Component;
 
+import baguni.batch.domain.link.service.LinkService;
 import baguni.common.config.RabbitmqConfig;
 import baguni.common.event.events.BookmarkCreateEvent;
 import baguni.common.event.events.LinkCreateEvent;

--- a/backend/baguni-common/src/main/java/baguni/common/config/RabbitmqConfig.java
+++ b/backend/baguni-common/src/main/java/baguni/common/config/RabbitmqConfig.java
@@ -29,6 +29,7 @@ public class RabbitmqConfig {
 
 	public static final class QUEUE {
 		public static final String LINK_RANKING = "queue.link-ranking";
+		public static final String LINK_RANKING_V2 = "queue.link-ranking-v2";
 		public static final String LINK_UPDATE = "queue.link-analyze";
 	}
 
@@ -58,6 +59,10 @@ public class RabbitmqConfig {
 		return new Queue(QUEUE.LINK_RANKING, false);
 	}
 
+	Queue linkRankingV2() {
+		return new Queue(QUEUE.LINK_RANKING_V2, false);
+	}
+
 	@Bean
 	Queue linkUpdate() {
 		return new Queue(QUEUE.LINK_UPDATE, false);
@@ -66,9 +71,14 @@ public class RabbitmqConfig {
 	@Bean
 	Declarables bindings() {
 		return new Declarables(
-			// link ranking
+			// link ranking v1 (기존 랭킹 서버)
 			BindingBuilder.bind(linkRanking()).to(exchange()).with("bookmark.create"),
 			BindingBuilder.bind(linkRanking()).to(exchange()).with("link.read"),
+
+			// link ranking v2 (batch)
+			BindingBuilder.bind(linkRankingV2()).to(exchange()).with("bookmark.create"),
+			BindingBuilder.bind(linkRankingV2()).to(exchange()).with("link.read"),
+
 			// link analyze
 			BindingBuilder.bind(linkUpdate()).to(exchange()).with("bookmark.create"),
 			BindingBuilder.bind(linkUpdate()).to(exchange()).with("link.*")

--- a/backend/baguni-domain/src/main/java/baguni/domain/infrastructure/link/LinkDataHandler.java
+++ b/backend/baguni-domain/src/main/java/baguni/domain/infrastructure/link/LinkDataHandler.java
@@ -1,5 +1,6 @@
 package baguni.domain.infrastructure.link;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
@@ -10,6 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 import baguni.common.exception.base.ServiceException;
 import baguni.domain.exception.link.LinkErrorCode;
 import baguni.domain.model.link.Link;
+import baguni.domain.model.link.LinkStats;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
 import lombok.RequiredArgsConstructor;
 
@@ -17,6 +19,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class LinkDataHandler {
 	private final LinkRepository linkRepository;
+	private final LinkStatsRepository linkStatsRepository;
 
 	@WithSpan
 	@Transactional(readOnly = true)
@@ -55,5 +58,17 @@ public class LinkDataHandler {
 		return linkRepository.findAllRssBlogArticlesOrderByPublishedDate(
 			PageRequest.of(0, limit)
 		);
+	}
+
+	@WithSpan
+	@Transactional(readOnly = true)
+	public Optional<LinkStats> findLinkStats(LocalDate date, String url) {
+		return linkStatsRepository.findByDateAndUrl(date, url);
+	}
+
+	@WithSpan
+	@Transactional
+	public LinkStats saveLinkStats(LinkStats linkStats) {
+		return linkStatsRepository.save(linkStats);
 	}
 }

--- a/backend/baguni-domain/src/main/java/baguni/domain/infrastructure/link/LinkStatsRepository.java
+++ b/backend/baguni-domain/src/main/java/baguni/domain/infrastructure/link/LinkStatsRepository.java
@@ -1,0 +1,19 @@
+package baguni.domain.infrastructure.link;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.domain.Limit;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import baguni.domain.model.link.LinkStats;
+
+public interface LinkStatsRepository extends JpaRepository<LinkStats, Long> {
+
+	Optional<LinkStats> findByDateAndUrl(LocalDate date, String url);
+
+	List<LinkStats> findByDateBetweenOrderByViewCountDesc(LocalDate start, LocalDate end, Limit limit);
+
+	List<LinkStats> findByDateBetweenOrderByBookmarkedCountDesc(LocalDate start, LocalDate end, Limit limit);
+}

--- a/backend/baguni-domain/src/main/java/baguni/domain/model/link/LinkStats.java
+++ b/backend/baguni-domain/src/main/java/baguni/domain/model/link/LinkStats.java
@@ -1,0 +1,72 @@
+package baguni.domain.model.link;
+
+import java.time.LocalDate;
+
+import org.hibernate.annotations.ColumnDefault;
+
+import baguni.common.exception.base.ServiceException;
+import baguni.domain.exception.link.LinkErrorCode;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Table(
+	name = "link_stats",
+	uniqueConstraints = {
+		@UniqueConstraint(
+			name = "UC_DATE_URL",
+			columnNames = {"date", "url"} // index(date, url)
+		)
+	}
+)
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LinkStats {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "id")
+	private Long id;
+
+	@Column(name = "date", updatable = false, nullable = false)
+	private LocalDate date; // 오직 날짜만 저장
+
+	@Column(name = "url", updatable = false, nullable = false, columnDefinition = "VARCHAR(2048)")
+	private String url;
+
+	@Column(name = "view_count", nullable = false)
+	@ColumnDefault("0")
+	private Long viewCount; // 조회수
+
+	@Column(name = "bookmarked_count", nullable = false)
+	@ColumnDefault("0")
+	private Long bookmarkedCount; // 북마크 횟수
+
+	// Static Factory Method -------------
+
+	public LinkStats(LocalDate date, String url) {
+		if (2048 < url.length()) {
+			throw new ServiceException(LinkErrorCode.LINK_URL_TOO_LONG);
+		}
+		this.date = date;
+		this.url = url;
+		this.viewCount = 0L;
+		this.bookmarkedCount = 0L;
+	}
+
+	public void incrementViewCount() {
+		this.viewCount++;
+	}
+
+	public void incrementBookmarkedCount() {
+		this.bookmarkedCount++;
+	}
+}

--- a/backend/baguni-domain/src/main/resources/db/migration/V4.6__add_link_statistic_table.sql
+++ b/backend/baguni-domain/src/main/resources/db/migration/V4.6__add_link_statistic_table.sql
@@ -1,0 +1,9 @@
+CREATE TABLE baguni_db.link_stats
+(
+    id               BIGINT AUTO_INCREMENT PRIMARY KEY,
+    date             DATE          NOT NULL,
+    url              VARCHAR(2048) NOT NULL,
+    view_count       BIGINT        NOT NULL DEFAULT 0,
+    bookmarked_count BIGINT        NOT NULL DEFAULT 0,
+    CONSTRAINT UC_DATE_URL UNIQUE (date, url(200))
+);


### PR DESCRIPTION
- Close #1143 

## What is this PR? 🔍
이 PR은 #1143 의 일부 작업입니다.

### PR 설명
![image](https://github.com/user-attachments/assets/5b1845c2-67a9-4cda-8244-73981a8cd692)
PR 반영시 배치서버도 집계하고, 랭킹 서버도 집계합니다. 
- 기능 : 배치 서버에 랭킹 집계 기능 추가 
- issue : #1143

기존 기능을 유지하면서, 배치에 집계 기능만 추가했습니다.
테스트 완료되기 전까진 기존 랭킹 큐를 유지할 예정입니다.

### 전체 작업 흐름
0. 작업 이전 일부 리팩토링 --> :heavy_check_mark:  `완료`
1. A - 기존 랭킹 서버를 유지하면서 Batch에 동일한 랭킹 집계 기능 구현 -->  :heavy_check_mark:  :ping_pong: `지금 pr`
1. B - 서버 반영 전에 mongo 데이터를 mysql로 이전  :heavy_check_mark:  :ping_pong: `지금 pr`
2.  랭킹 정보 획득 api 추가
3. 테스트 완료 후 랭킹 서버 + rest client + 관련 큐 삭제
4. 서버 2개로 줄이기가 끝나면 staging 브랜치 추가 

:warning: 이후 작업 및 테스트가 완료되었을 때 랭킹 서버를 완전히 삭제하겠습니다.



