### PR TITLE
[FEAT] 랭킹 api 교체 작업

### DIFF
--- a/backend/baguni-api/src/main/java/baguni/api/application/suggestion/controller/RankingApiController.java
+++ b/backend/baguni-api/src/main/java/baguni/api/application/suggestion/controller/RankingApiController.java
@@ -41,9 +41,8 @@ public class RankingApiController {
 		summary = "인기 픽 Top 10",
 		description = """
 				각 주제 별로 인기 조회수 글을 10개씩 획득 합니다.
-				1. 오늘 하루에 대한 실시간 링크 조회수 랭킹
-				2. 지난 7일 동안 링크 조회수 랭킹
-				3. 지난 한달간 픽된 (=북마크된) 링크 랭킹
+				1. 지난 7일 (오늘 제외) 동안 링크 조회수 Top 10
+				2. 지난 한달간 북마크 된 링크 Top 10
 			"""
 	)
 	@ApiResponses(value = {

--- a/backend/baguni-api/src/main/java/baguni/api/application/suggestion/controller/RankingApiController.java
+++ b/backend/baguni-api/src/main/java/baguni/api/application/suggestion/controller/RankingApiController.java
@@ -51,12 +51,9 @@ public class RankingApiController {
 	})
 	public ResponseEntity<RankingResponse> getSuggestionByViewCount(
 	) {
-		int LIMIT = 10;
-		var result = rankingService.getUrlRanking(LIMIT);
 		var response = new RankingResponse(
-			rankingDataToLinkInfo(result.dailyUrlViewRanking()),
-			rankingDataToLinkInfo(result.weeklyUrlViewRanking()),
-			rankingDataToLinkInfo(result.monthlyUrlPickRanking())
+			rankingDataToLinkInfo(rankingService.getWeeklyViewRank()),
+			rankingDataToLinkInfo(rankingService.getMonthlyBookmarkedRank())
 		);
 		return ResponseEntity.ok(response);
 	}

--- a/backend/baguni-api/src/main/java/baguni/api/application/suggestion/dto/RankingResponse.java
+++ b/backend/baguni-api/src/main/java/baguni/api/application/suggestion/dto/RankingResponse.java
@@ -6,8 +6,6 @@ import baguni.domain.infrastructure.link.dto.LinkInfo;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record RankingResponse(
-	@Schema(description = "오늘 하루 동안 인기 있는 링크 Top 10")
-	List<LinkInfo> dailyViewRanking,
 
 	@Schema(description = "지난 7일동안 링크 조회 수 Top 10")
 	List<LinkInfo> weeklyViewRanking,

--- a/backend/baguni-api/src/main/java/baguni/api/service/pick/service/PickService.java
+++ b/backend/baguni-api/src/main/java/baguni/api/service/pick/service/PickService.java
@@ -1,11 +1,8 @@
 package baguni.api.service.pick.service;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.ObjectUtils;
 import org.springframework.data.domain.Slice;
@@ -15,7 +12,6 @@ import org.springframework.transaction.annotation.Transactional;
 import baguni.common.exception.base.ServiceException;
 import baguni.domain.exception.folder.FolderErrorCode;
 import baguni.domain.exception.pick.PickErrorCode;
-import baguni.domain.exception.sharedFolder.SharedFolderErrorCode;
 import baguni.domain.exception.tag.TagErrorCode;
 import baguni.domain.infrastructure.pick.PickQuery;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
@@ -30,7 +26,6 @@ import baguni.domain.infrastructure.folder.FolderDataHandler;
 import baguni.domain.infrastructure.link.LinkDataHandler;
 import baguni.domain.infrastructure.pick.PickDataHandler;
 import baguni.domain.infrastructure.tag.TagDataHandler;
-import baguni.common.dto.UrlWithCount;
 import baguni.domain.model.folder.Folder;
 import baguni.domain.model.folder.FolderType;
 import baguni.domain.model.pick.Pick;
@@ -199,20 +194,6 @@ public class PickService {
 					  .map(pickMapper::toPickResult)
 					  .toList();
 		return pickMapper.toPickResultList(folderId, pickResultList);
-	}
-
-	/**
-	 * 랭킹 서버가 다운되어 있어도 내 픽 리스트는 조회가 가능하도록 처리.
-	 */
-	private Map<String, UrlWithCount> getViewRankingFromRankingServer() {
-		try {
-			return rankingService.getUrlRanking(10)
-								 .weeklyUrlViewRanking().stream()
-								 .collect(Collectors.toMap(UrlWithCount::url, Function.identity()));
-		} catch (Exception e) {
-			log.error("내 픽이 인기 픽인지 조회하려 했으나, 랭킹 서버와 통신할 수 없습니다! {}", e.getMessage(), e);
-			return Map.of();
-		}
 	}
 
 	private boolean isParentFolderChanged(Long originalFolderId, Long destinationFolderId) {

--- a/backend/baguni-api/src/main/java/baguni/api/service/ranking/dto/RankingResult.java
+++ b/backend/baguni-api/src/main/java/baguni/api/service/ranking/dto/RankingResult.java
@@ -5,8 +5,7 @@ import java.util.List;
 import baguni.common.dto.UrlWithCount;
 
 public record RankingResult(
-	List<UrlWithCount> dailyUrlViewRanking,
-	List<UrlWithCount> weeklyUrlViewRanking,
-	List<UrlWithCount> monthlyUrlPickRanking
+	List<UrlWithCount> weeklyUrlViewRank,
+	List<UrlWithCount> monthlyUrlBookmarkedRank
 ) {
 }

--- a/backend/baguni-api/src/main/java/baguni/api/service/ranking/service/RankingService.java
+++ b/backend/baguni-api/src/main/java/baguni/api/service/ranking/service/RankingService.java
@@ -1,28 +1,36 @@
 package baguni.api.service.ranking.service;
 
 import java.time.LocalDate;
+import java.util.List;
 
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
+import baguni.api.service.ranking.dto.RankingResult;
+import baguni.common.dto.UrlWithCount;
+import baguni.common.lib.cache.CacheType;
+import baguni.domain.infrastructure.link.LinkDataHandler;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
 import lombok.RequiredArgsConstructor;
-import baguni.api.service.ranking.dto.RankingResult;
 
 @Service
 @RequiredArgsConstructor
 public class RankingService {
 
+	/** @deprecated 삭제 예정 */
 	private final RankingApi rankingApi;
 
+	private final LinkDataHandler linkDataHandler;
+
+	/**
+	 * @deprecated 랭킹 서버를 없앰에 따라 삭제 예정
+	 */
 	@WithSpan
 	public RankingResult getUrlRanking(int limit) {
 		var currentDay = LocalDate.now();
 		var before1Day = currentDay.minusDays(1);
 		var before7Days = currentDay.minusDays(7);
 		var before30Days = currentDay.minusDays(30);
-
-		var dailyViewRanking = // 오늘
-			rankingApi.getUrlRankingByViewCount(currentDay, currentDay, limit).getBody();
 
 		var past7DaysViewRanking = // 일주일 전 ~ 어제
 			rankingApi.getUrlRankingByViewCount(before7Days, before1Day, limit).getBody();
@@ -35,6 +43,28 @@ public class RankingService {
 		var past30DaysPickRanking = // 한달 전 ~ 오늘
 			rankingApi.getUrlRankingByPickedCount(before30Days, currentDay, limit).getBody();
 
-		return new RankingResult(dailyViewRanking, past7DaysViewRanking, past30DaysPickRanking);
+		return new RankingResult(past7DaysViewRanking, past30DaysPickRanking);
+	}
+
+	@WithSpan
+	@Cacheable(cacheNames = CacheType.CACHE_NAME.WEEKLY_LINK_RANK)
+	public List<UrlWithCount> getWeeklyViewRank() {
+		var limit = 10;
+		var today = LocalDate.now();
+		return linkDataHandler
+			.getViewRank(today.minusDays(7), today.minusDays(1), limit)
+			.stream().map(r -> new UrlWithCount(r.getUrl(), r.getBookmarkedCount()))
+			.toList();
+	}
+
+	@WithSpan
+	@Cacheable(cacheNames = CacheType.CACHE_NAME.MONTHLY_PICK_RANK)
+	public List<UrlWithCount> getMonthlyBookmarkedRank() {
+		var limit = 10;
+		var today = LocalDate.now();
+		return linkDataHandler
+			.getBookmarkedRank(today.minusDays(30), today, limit)
+			.stream().map(r -> new UrlWithCount(r.getUrl(), r.getViewCount()))
+			.toList();
 	}
 }

--- a/backend/baguni-api/src/main/java/baguni/api/service/user/service/strategy/RankingInitStrategy.java
+++ b/backend/baguni-api/src/main/java/baguni/api/service/user/service/strategy/RankingInitStrategy.java
@@ -1,6 +1,5 @@
 package baguni.api.service.user.service.strategy;
 
-import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -8,7 +7,7 @@ import java.util.Objects;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
-import baguni.common.exception.base.ServiceException;
+import baguni.api.service.ranking.service.RankingService;
 import baguni.domain.infrastructure.user.dto.UserInfo;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -16,7 +15,6 @@ import baguni.domain.infrastructure.link.dto.LinkInfo;
 import baguni.api.service.link.service.LinkService;
 import baguni.domain.infrastructure.pick.dto.PickCommand;
 import baguni.api.service.pick.service.PickService;
-import baguni.api.service.ranking.service.RankingApi;
 import baguni.common.dto.UrlWithCount;
 
 @Slf4j
@@ -27,20 +25,14 @@ public class RankingInitStrategy implements ContentInitStrategy {
 
 	private static final Integer LOAD_LIMIT = 5;
 
-	private final RankingApi rankingApi;
 	private final PickService pickService;
 	private final LinkService linkService;
+	private final RankingService rankingService;
 
 	@Override
 	public void initContent(UserInfo info, Long folderId) {
-		var currentDay = LocalDate.now();
-		var before1Day = currentDay.minusDays(1);
-		var before30Days = currentDay.minusDays(30);
-
 		try {
-			var monthlyRanking = rankingApi
-				.getUrlRankingByViewCount(before30Days, before1Day, LOAD_LIMIT)
-				.getBody();
+			var monthlyRanking = rankingService.getMonthlyBookmarkedRank(LOAD_LIMIT);
 			savePickFromRankingList(info.id(), monthlyRanking, folderId);
 		} catch (Exception e) {
 			log.error("랭킹 정보를 이용한 사용자 폴더 초기화 실패.", e);

--- a/backend/baguni-common/src/main/java/baguni/common/lib/cache/CacheType.java
+++ b/backend/baguni-common/src/main/java/baguni/common/lib/cache/CacheType.java
@@ -7,7 +7,7 @@ public enum CacheType {
 	// ---------------------------------------------------
 	DAILY_LINK_RANK(CACHE_NAME.DAILY_LINK_RANK, 60 * 60, 10000), // 1시간
 	WEEKLY_LINK_RANK(CACHE_NAME.WEEKLY_LINK_RANK, 24 * 60 * 60, 10000), // 24시간
-	MONTHLY_PICK_RANK(CACHE_NAME.MONTHLY_PICK_RANK, 3 * 60 * 60, 10000), // 3시간
+	MONTHLY_PICK_RANK(CACHE_NAME.MONTHLY_PICK_RANK, 24 * 60 * 60, 10000), // 24시간
 	// ---------------------------------------------------
 	DAILY_RSS_BLOG_ARTICLE(CACHE_NAME.DAILY_RSS_BLOG_ARTICLE, 6 * 60 * 60, 10000); // 6시간
 

--- a/backend/baguni-domain/src/main/java/baguni/domain/infrastructure/link/LinkDataHandler.java
+++ b/backend/baguni-domain/src/main/java/baguni/domain/infrastructure/link/LinkDataHandler.java
@@ -76,12 +76,16 @@ public class LinkDataHandler {
 	@WithSpan
 	@Transactional(readOnly = true)
 	public List<LinkStats> getViewRank(LocalDate startDate, LocalDate endDate, Integer limit) {
-		return linkStatsRepository.findByDateBetweenOrderByViewCountDesc(startDate, endDate, Limit.of(limit));
+		return linkStatsRepository.findByDateBetweenAndViewCountGreaterThanOrderByViewCountDesc(
+			startDate, endDate, 0, Limit.of(limit)
+		);
 	}
 
 	@WithSpan
 	@Transactional(readOnly = true)
 	public List<LinkStats> getBookmarkedRank(LocalDate startDate, LocalDate endDate, Integer limit) {
-		return linkStatsRepository.findByDateBetweenOrderByBookmarkedCountDesc(startDate, endDate, Limit.of(limit));
+		return linkStatsRepository.findByDateBetweenAndBookmarkedCountGreaterThanOrderByBookmarkedCountDesc(
+			startDate, endDate, 0, Limit.of(limit)
+		);
 	}
 }

--- a/backend/baguni-domain/src/main/java/baguni/domain/infrastructure/link/LinkDataHandler.java
+++ b/backend/baguni-domain/src/main/java/baguni/domain/infrastructure/link/LinkDataHandler.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.Limit;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -70,5 +71,17 @@ public class LinkDataHandler {
 	@Transactional
 	public LinkStats saveLinkStats(LinkStats linkStats) {
 		return linkStatsRepository.save(linkStats);
+	}
+
+	@WithSpan
+	@Transactional(readOnly = true)
+	public List<LinkStats> getViewRank(LocalDate startDate, LocalDate endDate, Integer limit) {
+		return linkStatsRepository.findByDateBetweenOrderByViewCountDesc(startDate, endDate, Limit.of(limit));
+	}
+
+	@WithSpan
+	@Transactional(readOnly = true)
+	public List<LinkStats> getBookmarkedRank(LocalDate startDate, LocalDate endDate, Integer limit) {
+		return linkStatsRepository.findByDateBetweenOrderByBookmarkedCountDesc(startDate, endDate, Limit.of(limit));
 	}
 }

--- a/backend/baguni-domain/src/main/java/baguni/domain/infrastructure/link/LinkStatsRepository.java
+++ b/backend/baguni-domain/src/main/java/baguni/domain/infrastructure/link/LinkStatsRepository.java
@@ -13,7 +13,15 @@ public interface LinkStatsRepository extends JpaRepository<LinkStats, Long> {
 
 	Optional<LinkStats> findByDateAndUrl(LocalDate date, String url);
 
-	List<LinkStats> findByDateBetweenOrderByViewCountDesc(LocalDate start, LocalDate end, Limit limit);
+	List<LinkStats> findByDateBetweenAndViewCountGreaterThanOrderByViewCountDesc(
+		LocalDate start, LocalDate end,
+		int minCount, // 최소 기준 조회 수
+		Limit limit
+	);
 
-	List<LinkStats> findByDateBetweenOrderByBookmarkedCountDesc(LocalDate start, LocalDate end, Limit limit);
+	List<LinkStats> findByDateBetweenAndBookmarkedCountGreaterThanOrderByBookmarkedCountDesc(
+		LocalDate start, LocalDate end,
+		int minCount, // 최소 기준 북마크 횟수
+		Limit limit
+	);
 }


### PR DESCRIPTION
- Close #1143 

## What is this PR? 🔍
이 PR은 #1143 의 일부 작업입니다.

### PR 설명
- 기능 : 랭킹 api 구현 인프라를 mysql로 수정
- issue : #1143

### 전체 작업 흐름
- [x] 작업 이전 일부 리팩토링 
- [x] A - 기존 랭킹 서버를 유지하면서 Batch에 동일한 랭킹 집계 기능 구현
- [x] B - 서버 반영 전에 mongo 데이터를 mysql로 이전
- [x] 랭킹 정보 획득 api 를 mysql로 교체 ---------- :red_circle: `현재 PR`
- [ ] 랭킹 서버 모듈 일괄 삭제
- [ ] 개발/운영 랭킹서버 내리기 + Docker Compose 수정 + 래빗 접속 후 큐 삭제
