### PR TITLE
[FEAT] 링크 image_url 수정 API

### DIFF
--- a/backend/baguni-api/src/main/java/baguni/api/application/link/controller/LinkApiController.java
+++ b/backend/baguni-api/src/main/java/baguni/api/application/link/controller/LinkApiController.java
@@ -2,11 +2,16 @@ package baguni.api.application.link.controller;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import baguni.api.application.link.dto.LinkApiRequest;
+import baguni.infra.infrastructure.link.dto.LinkCommand;
 import baguni.infra.infrastructure.link.dto.LinkInfo;
+import baguni.security.annotation.LoginUserId;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -31,12 +36,25 @@ public class LinkApiController {
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "조회 성공")
 	})
-
 	public ResponseEntity<LinkApiResponse> getLinkData(
 		@Parameter(description = "og 태그 데이터 가져올 url") @RequestParam String url
 	) {
 		LinkInfo linkInfo = linkService.getLinkInfo(url);
 		var response = linkApiMapper.toLinkResponse(linkInfo);
 		return ResponseEntity.ok(response);
+	}
+
+	@PatchMapping
+	@Operation(summary = "링크 이미지 경로 수정", description = "불러올 수 없는 링크 이미지 경로를 수정합니다.")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "204", description = "수정 성공")
+	})
+	public ResponseEntity<Void> updateLinkData(
+		@LoginUserId Long userId,
+		@RequestBody LinkApiRequest.Update request
+	) {
+		var command = linkApiMapper.toUpdateCommand(userId, request);
+		linkService.updateLink(command);
+		return ResponseEntity.noContent().build();
 	}
 }

--- a/backend/baguni-api/src/main/java/baguni/api/application/link/dto/LinkApiMapper.java
+++ b/backend/baguni-api/src/main/java/baguni/api/application/link/dto/LinkApiMapper.java
@@ -4,6 +4,7 @@ import org.mapstruct.InjectionStrategy;
 import org.mapstruct.Mapper;
 import org.mapstruct.ReportingPolicy;
 
+import baguni.infra.infrastructure.link.dto.LinkCommand;
 import baguni.infra.infrastructure.link.dto.LinkInfo;
 
 @Mapper(
@@ -14,4 +15,6 @@ import baguni.infra.infrastructure.link.dto.LinkInfo;
 public interface LinkApiMapper {
 
 	LinkApiResponse toLinkResponse(LinkInfo linkInfo);
+
+	LinkCommand.Update toUpdateCommand(Long userId, LinkApiRequest.Update request);
 }

--- a/backend/baguni-api/src/main/java/baguni/api/application/link/dto/LinkApiRequest.java
+++ b/backend/baguni-api/src/main/java/baguni/api/application/link/dto/LinkApiRequest.java
@@ -1,0 +1,15 @@
+package baguni.api.application.link.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public class LinkApiRequest {
+
+	public record Update(
+		@Schema(example = "https://techblog.woowa.in/wp-content/uploads/2023/02/2023-우아한테크-로고-2-e1675772695839.png") @NotNull String imageUrl,
+		@Schema(example = "https://app.baguni.kr/image/og_image.png") @NotNull String updateImageUrl
+	) {
+	}
+}

--- a/backend/baguni-api/src/main/java/baguni/api/service/link/service/LinkService.java
+++ b/backend/baguni-api/src/main/java/baguni/api/service/link/service/LinkService.java
@@ -8,6 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import baguni.common.lib.cache.CacheType;
 import baguni.infra.infrastructure.link.dto.BlogLinkInfo;
+import baguni.infra.infrastructure.link.dto.LinkCommand;
 import baguni.infra.model.link.Link;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
 import lombok.RequiredArgsConstructor;
@@ -42,6 +43,12 @@ public class LinkService {
 	public LinkInfo saveLink(String url) {
 		Link link = linkDataHandler.getOptionalLink(url).orElseGet(() -> Link.createLink(url));
 		return linkMapper.of(linkDataHandler.saveLink(link));
+	}
+
+	@WithSpan
+	@Transactional
+	public void updateLink(LinkCommand.Update command) {
+		linkDataHandler.updateLink(command);
 	}
 
 	@WithSpan

--- a/backend/baguni-common/src/main/java/baguni/common/exception/error_code/LinkErrorCode.java
+++ b/backend/baguni-common/src/main/java/baguni/common/exception/error_code/LinkErrorCode.java
@@ -28,6 +28,9 @@ public class LinkErrorCode extends ErrorCode {
 	public static final ErrorCode LINK_ANALYZE_FAILURE = new LinkErrorCode(
 		"LI-005", HttpStatus.URI_TOO_LONG, "링크 분석에 실패했습니다", ErrorLevel.CAN_HAPPEN()
 	);
+	public static final ErrorCode LINK_IMAGE_NOT_FOUND = new LinkErrorCode(
+		"LI-006", HttpStatus.NOT_FOUND, "존재하지 않는 이미지 링크", ErrorLevel.SHOULD_NOT_HAPPEN()
+	);
 
 	protected LinkErrorCode(String code, HttpStatus status, String message, ErrorLevel errorLevel) {
 		super(code, status, message, errorLevel);

--- a/backend/baguni-infra/src/main/java/baguni/infra/infrastructure/link/LinkDataHandler.java
+++ b/backend/baguni-infra/src/main/java/baguni/infra/infrastructure/link/LinkDataHandler.java
@@ -51,9 +51,8 @@ public class LinkDataHandler {
 	@WithSpan
 	@Transactional
 	public void updateLink(LinkCommand.Update command) {
-		Link link = linkRepository.findByImageUrl(command.imageUrl())
-								  .orElseThrow(() -> new ServiceException(LinkErrorCode.LINK_IMAGE_NOT_FOUND));
-		link.updateMetadata(link.getTitle(), link.getDescription(), command.updateImageUrl());
+		List<Link> links = linkRepository.findAllByImageUrl(command.imageUrl());
+		links.forEach(link -> link.updateMetadata(link.getTitle(), link.getDescription(), command.updateImageUrl()));
 	}
 
 	@WithSpan

--- a/backend/baguni-infra/src/main/java/baguni/infra/infrastructure/link/LinkDataHandler.java
+++ b/backend/baguni-infra/src/main/java/baguni/infra/infrastructure/link/LinkDataHandler.java
@@ -11,6 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import baguni.common.exception.base.ServiceException;
 import baguni.common.exception.error_code.LinkErrorCode;
+import baguni.infra.infrastructure.link.dto.LinkCommand;
 import baguni.infra.model.link.Link;
 import baguni.infra.model.link.LinkStats;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
@@ -48,10 +49,19 @@ public class LinkDataHandler {
 	}
 
 	@WithSpan
+	@Transactional
+	public void updateLink(LinkCommand.Update command) {
+		Link link = linkRepository.findByImageUrl(command.imageUrl())
+								  .orElseThrow(() -> new ServiceException(LinkErrorCode.LINK_IMAGE_NOT_FOUND));
+		link.updateMetadata(link.getTitle(), link.getDescription(), command.updateImageUrl());
+	}
+
+	@WithSpan
 	@Transactional(readOnly = true)
 	public boolean existsByUrl(String url) {
 		return linkRepository.existsByUrl(url);
 	}
+
 
 	@WithSpan
 	@Transactional(readOnly = true)

--- a/backend/baguni-infra/src/main/java/baguni/infra/infrastructure/link/LinkRepository.java
+++ b/backend/baguni-infra/src/main/java/baguni/infra/infrastructure/link/LinkRepository.java
@@ -13,7 +13,7 @@ public interface LinkRepository extends JpaRepository<Link, Long> {
 
 	Optional<Link> findByUrl(String url);
 
-	Optional<Link> findByImageUrl(String imageUrl);
+	List<Link> findAllByImageUrl(String imageUrl);
 
 	List<Link> findByUrlIn(List<String> urlList);
 

--- a/backend/baguni-infra/src/main/java/baguni/infra/infrastructure/link/LinkRepository.java
+++ b/backend/baguni-infra/src/main/java/baguni/infra/infrastructure/link/LinkRepository.java
@@ -13,6 +13,8 @@ public interface LinkRepository extends JpaRepository<Link, Long> {
 
 	Optional<Link> findByUrl(String url);
 
+	Optional<Link> findByImageUrl(String imageUrl);
+
 	List<Link> findByUrlIn(List<String> urlList);
 
 	boolean existsByUrl(String url);

--- a/backend/baguni-infra/src/main/java/baguni/infra/infrastructure/link/dto/LinkCommand.java
+++ b/backend/baguni-infra/src/main/java/baguni/infra/infrastructure/link/dto/LinkCommand.java
@@ -1,0 +1,11 @@
+package baguni.infra.infrastructure.link.dto;
+
+public class LinkCommand {
+
+	public record Update(
+		Long userId,
+		String imageUrl,
+		String updateImageUrl
+	) {
+	}
+}


### PR DESCRIPTION
- Close #1140

## What is this PR? 🔍

- 기능 : 링크 image_url 수정 API
- issue : #1140

## Changes 📝
- 접근 불가능한 image_url은 우리 사이트의 기본 image_url로 변경할 수 있게 API 구현
- 접근이 불가능한 경우, 크롬 탭 favicon 자리에 무한 로딩하는 것을 확인할 수 있음(2분 지나면 타임아웃)

## Screenshot
<img width="535" alt="image" src="https://github.com/user-attachments/assets/3ac00303-2371-43bb-b327-3f359ac0137b" />